### PR TITLE
Sideload OCI images into the test Docker image

### DIFF
--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -108,11 +108,19 @@ RUN /src/k8s-snap/build-scripts/build-component.sh pebble
 ####################################################################################################
 ## IMAGE(build-preload-images): Fetch OCI images that can be pre-loaded to containerd
 
-# TODO(neoaggelos): fetch all used images from k8s-snap
 FROM build-k8sd AS build-preload-images
 WORKDIR /src/k8s-snap/src/k8s/tools
+RUN mkdir /out/images -p
+
+## NOTE(neoaggelos): example invocation
+## - regctl image export --platform local --user-agent containerd/v1.6.33 ghcr.io/canonical/pause:3.10 /out/images/ghcr.io-canonical-pause-3.10.tar
 RUN /out/bin/k8s list-images \
-    | xargs -n1 './regctl.sh image export --platform local --user-agent containerd/v1.6.33 $0 /out/images/$(echo $0 | tr ":/" "-").tar'
+    | xargs -n1 bash -c './regctl.sh image export \
+        --platform local \
+        --user-agent containerd/v1.6.33 \
+        $0 \
+        /out/images/$(echo $0 | tr ":/" "-").tar \
+        || true'
 
 ####################################################################################################
 ## IMAGE(k8s-snap): k8s-snap image
@@ -138,9 +146,6 @@ COPY --from=build-kubernetes /out /snap/k8s/current
 COPY --from=build-k8sd /out /snap/k8s/current
 COPY --from=build-pebble /out /snap/k8s/current
 COPY --from=build-preload-images /out/images /var/snap/k8s/common/images
-
-## NOTE(neoaggelos): OCI images
-COPY --from=build-preload-images /out /capi/images
 
 ## NOTE(neoaggelos): Install k8s files
 COPY --from=builder /src/k8s-snap/k8s /snap/k8s/current/k8s


### PR DESCRIPTION
### Summary

Fetch and sideload all OCI images needed by k8s-snap automatically. This is to reduce the need for fetching the same images multiple times.

### Notes

- Images are loaded to containerd using https://github.com/canonical/k8s-snap/pull/502
- Uses `k8s list-images` command from https://github.com/canonical/k8s-snap/pull/501