### PR TITLE
Cleanup microcluster/k8s when scaling down cluster nodes

### DIFF
--- a/bootstrap/api/v1beta2/ck8sconfig_types.go
+++ b/bootstrap/api/v1beta2/ck8sconfig_types.go
@@ -85,11 +85,20 @@ type CK8sControlPlaneConfig struct {
 
 	// MicroclusterPort is the port to use for microcluster. If unset, ":2380" (etcd peer) will be used.
 	// +optional
-	MicroclusterPort int `json:"microclusterPort,omitempty"`
+	MicroclusterPort *int `json:"microclusterPort,omitempty"`
 
 	// ExtraKubeAPIServerArgs is extra arguments to add to kube-apiserver.
 	// +optional
 	ExtraKubeAPIServerArgs map[string]*string `json:"extraKubeAPIServerArgs,omitempty"`
+}
+
+// GetMicroclusterPort returns the port to use for microcluster.
+// If unset, 2380 (etcd peer) will be used.
+func (c *CK8sControlPlaneConfig) GetMicroclusterPort() int {
+	if c.MicroclusterPort == nil {
+		return 2380
+	}
+	return *c.MicroclusterPort
 }
 
 // CK8sConfigStatus defines the observed state of CK8sConfig.

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -298,9 +298,7 @@ func (r *CK8sConfigReconciler) joinWorker(ctx context.Context, scope *Scope) err
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
 
-	// Accept any hostname by passing an empty string
-	// Some infrastructures will have machines where hostname and machine name do not match by design (e.g. AWS)
-	joinToken, err := workloadCluster.NewWorkerJoinToken(ctx, "")
+	joinToken, err := workloadCluster.NewWorkerJoinToken(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to request join token: %w", err)
 	}

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -235,7 +235,7 @@ func (r *CK8sConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
 
-	joinToken, err := workloadCluster.NewControlPlaneJoinToken(ctx, *authToken, scope.Config.Spec.ControlPlaneConfig.MicroclusterPort, machine.Name)
+	joinToken, err := workloadCluster.NewControlPlaneJoinToken(ctx, *authToken, scope.Config.Name)
 	if err != nil {
 		return fmt.Errorf("failed to request join token: %w", err)
 	}
@@ -308,7 +308,9 @@ func (r *CK8sConfigReconciler) joinWorker(ctx context.Context, scope *Scope) err
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
 
-	joinToken, err := workloadCluster.NewWorkerJoinToken(ctx, *authToken, scope.Config.Spec.ControlPlaneConfig.MicroclusterPort, machine.Name)
+	// Accept any hostname by passing an empty string
+	// Some infrastructures will have machines where hostname and machine name do not match by design (e.g. AWS)
+	joinToken, err := workloadCluster.NewWorkerJoinToken(ctx, *authToken, "")
 	if err != nil {
 		return fmt.Errorf("failed to request join token: %w", err)
 	}

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -235,7 +235,7 @@ func (r *CK8sConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
 
-	joinToken, err := workloadCluster.NewControlPlaneJoinToken(ctx, *authToken, scope.Config.Spec.ControlPlaneConfig.MicroclusterPort, scope.Config.Name)
+	joinToken, err := workloadCluster.NewControlPlaneJoinToken(ctx, *authToken, scope.Config.Spec.ControlPlaneConfig.MicroclusterPort, machine.Name)
 	if err != nil {
 		return fmt.Errorf("failed to request join token: %w", err)
 	}
@@ -308,7 +308,7 @@ func (r *CK8sConfigReconciler) joinWorker(ctx context.Context, scope *Scope) err
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
 
-	joinToken, err := workloadCluster.NewWorkerJoinToken(ctx, *authToken, scope.Config.Spec.ControlPlaneConfig.MicroclusterPort, scope.Config.Name)
+	joinToken, err := workloadCluster.NewWorkerJoinToken(ctx, *authToken, scope.Config.Spec.ControlPlaneConfig.MicroclusterPort, machine.Name)
 	if err != nil {
 		return fmt.Errorf("failed to request join token: %w", err)
 	}

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -220,7 +220,7 @@ func (r *CK8sConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 	// injects into config.Version values from top level object
 	r.reconcileTopLevelObjectSettings(scope.Cluster, machine, scope.Config)
 
-	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(scope.Cluster), scope.Config.Spec.ControlPlaneConfig.MicroclusterPort)
+	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(scope.Cluster), scope.Config.Spec.ControlPlaneConfig.GetMicroclusterPort())
 	if err != nil {
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
@@ -293,7 +293,7 @@ func (r *CK8sConfigReconciler) joinWorker(ctx context.Context, scope *Scope) err
 		return fmt.Errorf("auth token not yet generated")
 	}
 
-	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(scope.Cluster), scope.Config.Spec.ControlPlaneConfig.MicroclusterPort)
+	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(scope.Cluster), scope.Config.Spec.ControlPlaneConfig.GetMicroclusterPort())
 	if err != nil {
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
@@ -463,12 +463,7 @@ func (r *CK8sConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 
-	var microclusterPort int
-	microclusterPort = scope.Config.Spec.ControlPlaneConfig.MicroclusterPort
-	if microclusterPort == 0 {
-		microclusterPort = 2380
-	}
-
+	microclusterPort := scope.Config.Spec.ControlPlaneConfig.GetMicroclusterPort()
 	ds, err := ck8s.RenderK8sdProxyDaemonSetManifest(ck8s.K8sdProxyDaemonSetInput{K8sdPort: microclusterPort})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to render k8sd-proxy daemonset: %w", err)

--- a/controlplane/controllers/ck8scontrolplane_controller.go
+++ b/controlplane/controllers/ck8scontrolplane_controller.go
@@ -378,7 +378,7 @@ func (r *CK8sControlPlaneReconciler) updateStatus(ctx context.Context, kcp *cont
 		}
 	}
 
-	microclusterPort := kcp.Spec.CK8sConfigSpec.ControlPlaneConfig.MicroclusterPort
+	microclusterPort := kcp.Spec.CK8sConfigSpec.ControlPlaneConfig.GetMicroclusterPort()
 	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(cluster), microclusterPort)
 	if err != nil {
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
@@ -666,7 +666,7 @@ func (r *CK8sControlPlaneReconciler) reconcileControlPlaneConditions(ctx context
 		return nil
 	}
 
-	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.MicroclusterPort
+	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.GetMicroclusterPort()
 	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(controlPlane.Cluster), microclusterPort)
 	if err != nil {
 		return fmt.Errorf("cannot get remote client to workload cluster: %w", err)

--- a/controlplane/controllers/ck8scontrolplane_controller.go
+++ b/controlplane/controllers/ck8scontrolplane_controller.go
@@ -378,7 +378,8 @@ func (r *CK8sControlPlaneReconciler) updateStatus(ctx context.Context, kcp *cont
 		}
 	}
 
-	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(cluster))
+	microclusterPort := kcp.Spec.CK8sConfigSpec.ControlPlaneConfig.MicroclusterPort
+	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(cluster), microclusterPort)
 	if err != nil {
 		return fmt.Errorf("failed to create remote cluster client: %w", err)
 	}
@@ -665,7 +666,8 @@ func (r *CK8sControlPlaneReconciler) reconcileControlPlaneConditions(ctx context
 		return nil
 	}
 
-	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(controlPlane.Cluster))
+	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.MicroclusterPort
+	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(controlPlane.Cluster), microclusterPort)
 	if err != nil {
 		return fmt.Errorf("cannot get remote client to workload cluster: %w", err)
 	}

--- a/controlplane/controllers/ck8scontrolplane_controller.go
+++ b/controlplane/controllers/ck8scontrolplane_controller.go
@@ -299,7 +299,7 @@ func (r *CK8sControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr c
 
 	if r.managementClusterUncached == nil {
 		r.managementClusterUncached = &ck8s.Management{
-			Client:          mgr.GetAPIReader(),
+			Client:          mgr.GetClient(),
 			K8sdDialTimeout: r.K8sdDialTimeout,
 		}
 	}

--- a/controlplane/controllers/machine_controller.go
+++ b/controlplane/controllers/machine_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/canonical/cluster-api-k8s/pkg/ck8s"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,10 +25,7 @@ type MachineReconciler struct {
 
 	K8sdDialTimeout time.Duration
 
-	// NOTE(neoaggelos): See note below
-	/**
 	managementCluster ck8s.ManagementCluster
-	**/
 }
 
 func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, log *logr.Logger) error {
@@ -36,15 +34,15 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		Build(r)
 
 	// NOTE(neoaggelos): See note below
-	/**
 	if r.managementCluster == nil {
 		r.managementCluster = &ck8s.Management{
-			Client:          r.Client,
-			EtcdDialTimeout: r.EtcdDialTimeout,
-			EtcdCallTimeout: r.EtcdCallTimeout,
+			Client: r.Client,
+			/*
+				EtcdDialTimeout: r.EtcdDialTimeout,
+				EtcdCallTimeout: r.EtcdCallTimeout,
+			*/
 		}
 	}
-	**/
 
 	return err
 }
@@ -101,7 +99,6 @@ func (r *MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			logger.Info("unable to get cluster.")
 			return ctrl.Result{}, errors.Wrapf(err, "unable to get cluster")
 		}
-
 		workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(cluster))
 		if err != nil {
 			logger.Error(err, "failed to create client to workload cluster")

--- a/controlplane/controllers/machine_controller.go
+++ b/controlplane/controllers/machine_controller.go
@@ -36,7 +36,8 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 	// NOTE(neoaggelos): See note below
 	if r.managementCluster == nil {
 		r.managementCluster = &ck8s.Management{
-			Client: r.Client,
+			Client:          r.Client,
+			K8sdDialTimeout: r.K8sdDialTimeout,
 			/*
 				EtcdDialTimeout: r.EtcdDialTimeout,
 				EtcdCallTimeout: r.EtcdCallTimeout,

--- a/controlplane/controllers/remediation.go
+++ b/controlplane/controllers/remediation.go
@@ -28,6 +28,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -234,6 +235,18 @@ func (r *CK8sControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.Cont
 			}
 		}
 		**/
+	}
+
+	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.MicroclusterPort
+	clusterObjectKey := util.ObjectKey(controlPlane.Cluster)
+	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, clusterObjectKey, microclusterPort)
+	if err != nil {
+		log.Error(err, "failed to create client to workload cluster")
+		return ctrl.Result{}, errors.Wrapf(err, "failed to create client to workload cluster")
+	}
+
+	if err := workloadCluster.RemoveMachineFromCluster(ctx, machineToBeRemediated); err != nil {
+		log.Error(err, "failed to remove machine from microcluster")
 	}
 
 	// Delete the machine

--- a/controlplane/controllers/remediation.go
+++ b/controlplane/controllers/remediation.go
@@ -237,7 +237,7 @@ func (r *CK8sControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.Cont
 		**/
 	}
 
-	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.MicroclusterPort
+	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.GetMicroclusterPort()
 	clusterObjectKey := util.ObjectKey(controlPlane.Cluster)
 	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, clusterObjectKey, microclusterPort)
 	if err != nil {

--- a/controlplane/controllers/scale.go
+++ b/controlplane/controllers/scale.go
@@ -176,8 +176,7 @@ func (r *CK8sControlPlaneReconciler) scaleDownControlPlane(
 		return ctrl.Result{}, fmt.Errorf("auth token not yet generated")
 	}
 
-	err = workloadCluster.RemoveMachineFromCluster(ctx, machineToDelete, *authToken)
-	if err != nil {
+	if err := workloadCluster.RemoveMachineFromCluster(ctx, machineToDelete, *authToken); err != nil {
 		logger.Error(err, "failed to remove machine from microcluster")
 	}
 

--- a/controlplane/controllers/scale.go
+++ b/controlplane/controllers/scale.go
@@ -159,7 +159,7 @@ func (r *CK8sControlPlaneReconciler) scaleDownControlPlane(
 	}
 	**/
 
-	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.MicroclusterPort
+	microclusterPort := controlPlane.KCP.Spec.CK8sConfigSpec.ControlPlaneConfig.GetMicroclusterPort()
 	clusterObjectKey := util.ObjectKey(cluster)
 	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, clusterObjectKey, microclusterPort)
 	if err != nil {

--- a/controlplane/controllers/scale.go
+++ b/controlplane/controllers/scale.go
@@ -176,9 +176,7 @@ func (r *CK8sControlPlaneReconciler) scaleDownControlPlane(
 		return ctrl.Result{}, fmt.Errorf("auth token not yet generated")
 	}
 
-	// TODO: Get from CK8sConfig
-	microclusterPort := 2380
-	err = workloadCluster.RemoveMachineFromCluster(ctx, machineToDelete, *authToken, microclusterPort)
+	err = workloadCluster.RemoveMachineFromCluster(ctx, machineToDelete, *authToken)
 	if err != nil {
 		logger.Error(err, "failed to remove machine from microcluster")
 	}

--- a/controlplane/main.go
+++ b/controlplane/main.go
@@ -66,7 +66,7 @@ func main() {
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
-	flag.DurationVar(&k8sdDialTimeout, "k8sd-dial-timeout-duration", 10*time.Second,
+	flag.DurationVar(&k8sdDialTimeout, "k8sd-dial-timeout-duration", 60*time.Second,
 		"Duration that the proxy client waits at most to establish a connection with k8sd")
 
 	flag.Parse()

--- a/pkg/ck8s/api/cluster_node.go
+++ b/pkg/ck8s/api/cluster_node.go
@@ -1,0 +1,7 @@
+package apiv1
+
+// RemoveNodeRequest is used to request to remove a node from the cluster.
+type RemoveNodeRequest struct {
+	Name  string `json:"name"`
+	Force bool   `json:"force"`
+}

--- a/pkg/ck8s/management_cluster.go
+++ b/pkg/ck8s/management_cluster.go
@@ -25,7 +25,7 @@ type ManagementCluster interface {
 type Management struct {
 	ManagementCluster
 
-	Client client.Reader
+	Client client.Client
 
 	K8sdDialTimeout time.Duration
 }
@@ -88,7 +88,7 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.O
 		return nil, &RemoteClusterConnectionError{Name: clusterKey.String(), Err: err}
 	}
 
-	authToken, err := token.Lookup(ctx, c, clusterKey)
+	authToken, err := token.Lookup(ctx, m.Client, clusterKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup auth token: %w", err)
 	}
@@ -171,3 +171,5 @@ func (m *Management) getEtcdCAKeyPair(ctx context.Context, clusterKey client.Obj
 	return crtData, keyData, nil
 }
 **/
+
+var _ ManagementCluster = &Management{}

--- a/pkg/ck8s/management_cluster.go
+++ b/pkg/ck8s/management_cluster.go
@@ -97,12 +97,16 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.O
 		return nil, fmt.Errorf("auth token not yet generated")
 	}
 
+	if microclusterPort == 0 {
+		microclusterPort = 2380
+	}
+
 	workload := &Workload{
-		AuthToken:           *authToken,
+		authToken:           *authToken,
 		Client:              c,
 		ClientRestConfig:    restConfig,
 		K8sdClientGenerator: g,
-		MicroclusterPort:    microclusterPort,
+		microclusterPort:    microclusterPort,
 
 		/**
 		CoreDNSMigrator: &CoreDNSMigrator{},

--- a/pkg/ck8s/management_cluster.go
+++ b/pkg/ck8s/management_cluster.go
@@ -97,10 +97,6 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.O
 		return nil, fmt.Errorf("auth token not yet generated")
 	}
 
-	if microclusterPort == 0 {
-		microclusterPort = 2380
-	}
-
 	workload := &Workload{
 		authToken:           *authToken,
 		Client:              c,

--- a/pkg/ck8s/workload_cluster.go
+++ b/pkg/ck8s/workload_cluster.go
@@ -44,7 +44,7 @@ type WorkloadCluster interface {
 	UpdateAgentConditions(ctx context.Context, controlPlane *ControlPlane)
 	UpdateEtcdConditions(ctx context.Context, controlPlane *ControlPlane)
 	NewControlPlaneJoinToken(ctx context.Context, name string) (string, error)
-	NewWorkerJoinToken(ctx context.Context, name string) (string, error)
+	NewWorkerJoinToken(ctx context.Context) (string, error)
 
 	RemoveMachineFromCluster(ctx context.Context, machine *clusterv1.Machine) error
 
@@ -212,8 +212,10 @@ func (w *Workload) NewControlPlaneJoinToken(ctx context.Context, name string) (s
 
 // NewWorkerJoinToken creates a new join token for a worker node.
 // NewWorkerJoinToken reaches out to the control-plane of the workload cluster via k8sd-proxy client.
-func (w *Workload) NewWorkerJoinToken(ctx context.Context, name string) (string, error) {
-	return w.requestJoinToken(ctx, name, true)
+func (w *Workload) NewWorkerJoinToken(ctx context.Context) (string, error) {
+	// Accept any hostname by passing an empty string
+	// Some infrastructures will have machines where hostname and machine name do not match by design (e.g. AWS)
+	return w.requestJoinToken(ctx, "", true)
 }
 
 // requestJoinToken requests a join token from the existing control-plane nodes via the k8sd proxy.

--- a/pkg/ck8s/workload_cluster.go
+++ b/pkg/ck8s/workload_cluster.go
@@ -263,7 +263,7 @@ func (w *Workload) doK8sdRequest(ctx context.Context, method, endpoint string, r
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
-	fmt.Println(w.authToken)
+
 	req.Header.Add("capi-auth-token", w.authToken)
 	res, err := k8sdProxy.Client.Do(req)
 	if err != nil {

--- a/pkg/ck8s/workload_cluster.go
+++ b/pkg/ck8s/workload_cluster.go
@@ -271,11 +271,6 @@ func (w *Workload) doK8sdRequest(ctx context.Context, method, endpoint string, r
 	}
 	defer res.Body.Close()
 
-	if response == nil {
-		// Nothing to decode
-		return nil
-	}
-
 	var responseBody wrappedResponse
 	if err := json.NewDecoder(res.Body).Decode(&responseBody); err != nil {
 		return fmt.Errorf("failed to parse HTTP response: %w", err)
@@ -285,6 +280,10 @@ func (w *Workload) doK8sdRequest(ctx context.Context, method, endpoint string, r
 	}
 	if responseBody.Error != "" {
 		return fmt.Errorf("k8sd request failed: %s", responseBody.Error)
+	}
+	if responseBody.Metadata == nil {
+		// Nothing to decode
+		return nil
 	}
 	if err := json.Unmarshal(responseBody.Metadata, response); err != nil {
 		return fmt.Errorf("failed to parse HTTP response: %w", err)

--- a/pkg/cloudinit/common.go
+++ b/pkg/cloudinit/common.go
@@ -83,8 +83,5 @@ func NewBaseCloudConfig(data BaseUserData) (CloudConfig, error) {
 }
 
 func makeMicroclusterAddress(address string, port int) string {
-	if port == 0 {
-		port = 2380
-	}
 	return net.JoinHostPort(address, strconv.Itoa(port))
 }

--- a/templates/docker/cluster-template.yaml
+++ b/templates/docker/cluster-template.yaml
@@ -57,7 +57,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: worker-md-0
+  name: ${CLUSTER_NAME}-worker-md-0
 spec:
   clusterName: ${CLUSTER_NAME}
   replicas: ${WORKER_MACHINE_COUNT}


### PR DESCRIPTION
## Summary

Remove nodes from microcluster and k8s when scaling down the cluster.

## Notable changes

* Moved k8sd-proxy requests into generic separate function
* Added k8sd-proxy blacklist options to ensure the proxy is not targeting the machine that is removed
* Added `RemoveMachineFromCluster` method to workload cluster

## Tests

Manual tests for now:
* Created 4 CP node cluster - removed 1 of them again
  -> verified on remaining nodes that node is removed from microcluster and roles are updated
* Created 1 CP, 1 worker cluster - removed worker
  -> verified that worker is removed from k8s