### PR TITLE
Add unit tests for `cloudinit` generation

### DIFF
--- a/pkg/cloudinit/controlplane_init_test.go
+++ b/pkg/cloudinit/controlplane_init_test.go
@@ -68,7 +68,7 @@ func TestNewInitControlPlane(t *testing.T) {
 	}))
 
 	// NOTE (mateoflorido): Keep this test in sync with the expected paths in the controlplane_init.go file.
-	expectedPaths := []interface{}{
+	g.Expect(config.WriteFiles).To(ConsistOf(
 		HaveField("Path", "/capi/scripts/install.sh"),
 		HaveField("Path", "/capi/scripts/bootstrap.sh"),
 		HaveField("Path", "/capi/scripts/load-images.sh"),
@@ -83,9 +83,7 @@ func TestNewInitControlPlane(t *testing.T) {
 		HaveField("Path", "/capi/etc/snap-track"),
 		HaveField("Path", "/capi/manifests/00-k8sd-proxy.yaml"),
 		HaveField("Path", "/tmp/file"),
-	}
-
-	g.Expect(config.WriteFiles).To(ConsistOf(expectedPaths...), "Some /capi/scripts files are missing")
+	), "Some /capi/scripts files are missing")
 }
 
 func TestNewInitControlPlaneInvalidVersionError(t *testing.T) {

--- a/pkg/cloudinit/controlplane_init_test.go
+++ b/pkg/cloudinit/controlplane_init_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cloudinit_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -68,70 +67,25 @@ func TestNewInitControlPlane(t *testing.T) {
 		"postrun2",
 	}))
 
-	// Define the expected files to write with their content, path, permissions, and owner.
-	expectedWriteFiles := []cloudinit.File{
-		{
-			Path:        "/tmp/file",
-			Content:     "test file",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/config.yaml",
-			Content:     "### config file ###",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/microcluster-address",
-			Content:     "10.0.0.10:2380",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/snap-track",
-			Content:     "1.30-classic/stable",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/token",
-			Content:     "test-token",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/manifests/00-k8sd-proxy.yaml",
-			Content:     "test-daemonset",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
+	// NOTE (mateoflorido): Keep this test in sync with the expected paths in the controlplane_init.go file.
+	expectedPaths := []interface{}{
+		HaveField("Path", "/capi/scripts/install.sh"),
+		HaveField("Path", "/capi/scripts/bootstrap.sh"),
+		HaveField("Path", "/capi/scripts/load-images.sh"),
+		HaveField("Path", "/capi/scripts/join-cluster.sh"),
+		HaveField("Path", "/capi/scripts/wait-apiserver-ready.sh"),
+		HaveField("Path", "/capi/scripts/deploy-manifests.sh"),
+		HaveField("Path", "/capi/scripts/configure-token.sh"),
+		HaveField("Path", "/capi/scripts/create-sentinel-bootstrap.sh"),
+		HaveField("Path", "/capi/etc/config.yaml"),
+		HaveField("Path", "/capi/etc/microcluster-address"),
+		HaveField("Path", "/capi/etc/token"),
+		HaveField("Path", "/capi/etc/snap-track"),
+		HaveField("Path", "/capi/manifests/00-k8sd-proxy.yaml"),
+		HaveField("Path", "/tmp/file"),
 	}
 
-	scriptFiles := map[string]string{
-		"./scripts/install.sh":                   "/capi/scripts/install.sh",
-		"./scripts/bootstrap.sh":                 "/capi/scripts/bootstrap.sh",
-		"./scripts/load-images.sh":               "/capi/scripts/load-images.sh",
-		"./scripts/join-cluster.sh":              "/capi/scripts/join-cluster.sh",
-		"./scripts/wait-apiserver-ready.sh":      "/capi/scripts/wait-apiserver-ready.sh",
-		"./scripts/deploy-manifests.sh":          "/capi/scripts/deploy-manifests.sh",
-		"./scripts/configure-token.sh":           "/capi/scripts/configure-token.sh",
-		"./scripts/create-sentinel-bootstrap.sh": "/capi/scripts/create-sentinel-bootstrap.sh",
-	}
-
-	// Read the content of each script file and append it to the expected write files.
-	for relativePath, scriptPath := range scriptFiles {
-		content, err := os.ReadFile(relativePath)
-		g.Expect(err).NotTo(HaveOccurred())
-		expectedWriteFiles = append(expectedWriteFiles, cloudinit.File{
-			Path:        scriptPath,
-			Content:     string(content),
-			Permissions: "0500",
-			Owner:       "root:root",
-		})
-	}
-
-	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
+	g.Expect(config.WriteFiles).To(ConsistOf(expectedPaths...), "Some /capi/scripts files are missing")
 }
 
 func TestNewInitControlPlaneInvalidVersionError(t *testing.T) {

--- a/pkg/cloudinit/controlplane_init_test.go
+++ b/pkg/cloudinit/controlplane_init_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudinit_test
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -40,18 +41,25 @@ func TestNewInitControlPlane(t *testing.T) {
 				Owner:       "root:root",
 			}},
 			ConfigFileContents:  "### config file ###",
-			MicroclusterAddress: ":2380",
+			MicroclusterAddress: "10.0.0.10",
 		},
+		Token:              "test-token",
+		K8sdProxyDaemonSet: "test-daemonset",
 	})
 
-	// TODO: add tests for expected files and commands
-	g.Expect(err).To(BeNil())
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Verify the boot commands.
+	g.Expect(config.BootCommands).To(Equal([]string{"bootcmd"}))
+
+	// Verify the run commands.
 	g.Expect(config.RunCommands).To(Equal([]string{
 		"set -x",
 		"prerun1",
 		"prerun2",
 		"/capi/scripts/install.sh",
 		"/capi/scripts/bootstrap.sh",
+		"/capi/scripts/load-images.sh",
 		"/capi/scripts/wait-apiserver-ready.sh",
 		"/capi/scripts/deploy-manifests.sh",
 		"/capi/scripts/configure-token.sh",
@@ -59,4 +67,101 @@ func TestNewInitControlPlane(t *testing.T) {
 		"postrun1",
 		"postrun2",
 	}))
+
+	// Define the expected files to write with their content, path, permissions, and owner.
+	expectedWriteFiles := []cloudinit.File{
+		{
+			Path:        "/tmp/file",
+			Content:     "test file",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/config.yaml",
+			Content:     "### config file ###",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/microcluster-address",
+			Content:     "10.0.0.10:2380",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/snap-track",
+			Content:     "1.30-classic/stable",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/token",
+			Content:     "test-token",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/manifests/00-k8sd-proxy.yaml",
+			Content:     "test-daemonset",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+	}
+
+	scriptFiles := map[string]string{
+		"./scripts/install.sh":                   "/capi/scripts/install.sh",
+		"./scripts/bootstrap.sh":                 "/capi/scripts/bootstrap.sh",
+		"./scripts/load-images.sh":               "/capi/scripts/load-images.sh",
+		"./scripts/join-cluster.sh":              "/capi/scripts/join-cluster.sh",
+		"./scripts/wait-apiserver-ready.sh":      "/capi/scripts/wait-apiserver-ready.sh",
+		"./scripts/deploy-manifests.sh":          "/capi/scripts/deploy-manifests.sh",
+		"./scripts/configure-token.sh":           "/capi/scripts/configure-token.sh",
+		"./scripts/create-sentinel-bootstrap.sh": "/capi/scripts/create-sentinel-bootstrap.sh",
+	}
+
+	// Read the content of each script file and append it to the expected write files.
+	for relativePath, scriptPath := range scriptFiles {
+		content, err := os.ReadFile(relativePath)
+		g.Expect(err).NotTo(HaveOccurred())
+		expectedWriteFiles = append(expectedWriteFiles, cloudinit.File{
+			Path:        scriptPath,
+			Content:     string(content),
+			Permissions: "0500",
+			Owner:       "root:root",
+		})
+	}
+
+	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
+}
+
+func TestNewInitControlPlaneError(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := cloudinit.NewInitControlPlane(cloudinit.InitControlPlaneInput{
+		BaseUserData: cloudinit.BaseUserData{
+			KubernetesVersion: "invalid-version",
+			BootCommands:      []string{"bootcmd"},
+			PreRunCommands:    []string{"prerun1", "prerun2"},
+			PostRunCommands:   []string{"postrun1", "postrun2"},
+		}})
+
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestNewInitControlPlaneAirGapped(t *testing.T) {
+	g := NewWithT(t)
+
+	config, err := cloudinit.NewInitControlPlane(cloudinit.InitControlPlaneInput{
+		BaseUserData: cloudinit.BaseUserData{
+			KubernetesVersion: "v1.30.0",
+			BootCommands:      []string{"bootcmd"},
+			PreRunCommands:    []string{"prerun1", "prerun2"},
+			PostRunCommands:   []string{"postrun1", "postrun2"},
+			AirGapped:         true,
+		}})
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify the run commands is missing install.sh script.
+	g.Expect(config.RunCommands).NotTo(ContainElement("/capi/scripts/install.sh"))
 }

--- a/pkg/cloudinit/controlplane_init_test.go
+++ b/pkg/cloudinit/controlplane_init_test.go
@@ -134,7 +134,7 @@ func TestNewInitControlPlane(t *testing.T) {
 	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
 }
 
-func TestNewInitControlPlaneError(t *testing.T) {
+func TestNewInitControlPlaneInvalidVersionError(t *testing.T) {
 	g := NewWithT(t)
 
 	_, err := cloudinit.NewInitControlPlane(cloudinit.InitControlPlaneInput{

--- a/pkg/cloudinit/controlplane_join_test.go
+++ b/pkg/cloudinit/controlplane_join_test.go
@@ -1,7 +1,6 @@
 package cloudinit_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -49,64 +48,24 @@ func TestNewJoinControlPlane(t *testing.T) {
 		"postrun2",
 	}))
 
-	// Define the expected extra files with their content, path, permissions, and owner.
-	expectedWriteFiles := []cloudinit.File{
-		{
-			Path:        "/tmp/file",
-			Content:     "test file",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/config.yaml",
-			Content:     "### config file ###",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/snap-track",
-			Content:     "1.30-classic/stable",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/microcluster-address",
-			Content:     "10.0.0.11:2380",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/join-token",
-			Content:     "test-token",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
+	// NOTE (mateoflorido): Keep this test in sync with the expected paths in the controlplane_join.go file.
+	expectedPaths := []interface{}{
+		HaveField("Path", "/capi/scripts/install.sh"),
+		HaveField("Path", "/capi/scripts/bootstrap.sh"),
+		HaveField("Path", "/capi/scripts/load-images.sh"),
+		HaveField("Path", "/capi/scripts/join-cluster.sh"),
+		HaveField("Path", "/capi/scripts/wait-apiserver-ready.sh"),
+		HaveField("Path", "/capi/scripts/deploy-manifests.sh"),
+		HaveField("Path", "/capi/scripts/configure-token.sh"),
+		HaveField("Path", "/capi/scripts/create-sentinel-bootstrap.sh"),
+		HaveField("Path", "/capi/etc/config.yaml"),
+		HaveField("Path", "/capi/etc/microcluster-address"),
+		HaveField("Path", "/capi/etc/join-token"),
+		HaveField("Path", "/capi/etc/snap-track"),
+		HaveField("Path", "/tmp/file"),
 	}
 
-	scriptFiles := map[string]string{
-		"./scripts/install.sh":                   "/capi/scripts/install.sh",
-		"./scripts/bootstrap.sh":                 "/capi/scripts/bootstrap.sh",
-		"./scripts/load-images.sh":               "/capi/scripts/load-images.sh",
-		"./scripts/join-cluster.sh":              "/capi/scripts/join-cluster.sh",
-		"./scripts/wait-apiserver-ready.sh":      "/capi/scripts/wait-apiserver-ready.sh",
-		"./scripts/deploy-manifests.sh":          "/capi/scripts/deploy-manifests.sh",
-		"./scripts/configure-token.sh":           "/capi/scripts/configure-token.sh",
-		"./scripts/create-sentinel-bootstrap.sh": "/capi/scripts/create-sentinel-bootstrap.sh",
-	}
-
-	// Read the content of each script file and append it to the expected write files.
-	for relativePath, scriptPath := range scriptFiles {
-		content, err := os.ReadFile(relativePath)
-		g.Expect(err).NotTo(HaveOccurred())
-		expectedWriteFiles = append(expectedWriteFiles, cloudinit.File{
-			Path:        scriptPath,
-			Content:     string(content),
-			Permissions: "0500",
-			Owner:       "root:root",
-		})
-	}
-
-	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
+	g.Expect(config.WriteFiles).To(ConsistOf(expectedPaths...), "Some /capi/scripts files are missing")
 }
 
 func TestNewJoinControlPlaneInvalidVersionError(t *testing.T) {

--- a/pkg/cloudinit/controlplane_join_test.go
+++ b/pkg/cloudinit/controlplane_join_test.go
@@ -109,7 +109,7 @@ func TestNewJoinControlPlane(t *testing.T) {
 	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
 }
 
-func TestNewJoinControlPlaneError(t *testing.T) {
+func TestNewJoinControlPlaneInvalidVersionError(t *testing.T) {
 	g := NewWithT(t)
 
 	_, err := cloudinit.NewJoinControlPlane(cloudinit.JoinControlPlaneInput{

--- a/pkg/cloudinit/controlplane_join_test.go
+++ b/pkg/cloudinit/controlplane_join_test.go
@@ -1,6 +1,7 @@
 package cloudinit_test
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -24,12 +25,17 @@ func TestNewJoinControlPlane(t *testing.T) {
 				Owner:       "root:root",
 			}},
 			ConfigFileContents:  "### config file ###",
-			MicroclusterAddress: ":2380",
+			MicroclusterAddress: "10.0.0.11",
 		},
+		JoinToken: "test-token",
 	})
 
-	// TODO: add tests for expected files and commands
-	g.Expect(err).To(BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify the boot commands.
+	g.Expect(config.BootCommands).To(Equal([]string{"bootcmd"}))
+
+	// Verify the run commands.
 	g.Expect(config.RunCommands).To(Equal([]string{
 		"set -x",
 		"prerun1",
@@ -42,4 +48,99 @@ func TestNewJoinControlPlane(t *testing.T) {
 		"postrun1",
 		"postrun2",
 	}))
+
+	// Define the expected extra files with their content, path, permissions, and owner.
+	expectedWriteFiles := []cloudinit.File{
+		{
+			Path:        "/tmp/file",
+			Content:     "test file",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/config.yaml",
+			Content:     "### config file ###",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/snap-track",
+			Content:     "1.30-classic/stable",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/microcluster-address",
+			Content:     "10.0.0.11:2380",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+		{
+			Path:        "/capi/etc/join-token",
+			Content:     "test-token",
+			Permissions: "0400",
+			Owner:       "root:root",
+		},
+	}
+
+	scriptFiles := map[string]string{
+		"./scripts/install.sh":                   "/capi/scripts/install.sh",
+		"./scripts/bootstrap.sh":                 "/capi/scripts/bootstrap.sh",
+		"./scripts/load-images.sh":               "/capi/scripts/load-images.sh",
+		"./scripts/join-cluster.sh":              "/capi/scripts/join-cluster.sh",
+		"./scripts/wait-apiserver-ready.sh":      "/capi/scripts/wait-apiserver-ready.sh",
+		"./scripts/deploy-manifests.sh":          "/capi/scripts/deploy-manifests.sh",
+		"./scripts/configure-token.sh":           "/capi/scripts/configure-token.sh",
+		"./scripts/create-sentinel-bootstrap.sh": "/capi/scripts/create-sentinel-bootstrap.sh",
+	}
+
+	// Read the content of each script file and append it to the expected write files.
+	for relativePath, scriptPath := range scriptFiles {
+		content, err := os.ReadFile(relativePath)
+		g.Expect(err).NotTo(HaveOccurred())
+		expectedWriteFiles = append(expectedWriteFiles, cloudinit.File{
+			Path:        scriptPath,
+			Content:     string(content),
+			Permissions: "0500",
+			Owner:       "root:root",
+		})
+	}
+
+	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
+}
+
+func TestNewJoinControlPlaneError(t *testing.T) {
+	g := NewWithT(t)
+
+	_, err := cloudinit.NewJoinControlPlane(cloudinit.JoinControlPlaneInput{
+		BaseUserData: cloudinit.BaseUserData{
+			KubernetesVersion: "invalid-version",
+			BootCommands:      []string{"bootcmd"},
+			PreRunCommands:    []string{"prerun1", "prerun2"},
+			PostRunCommands:   []string{"postrun1", "postrun2"},
+		},
+		JoinToken: "test-token",
+	})
+
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestNewJoinControlPlaneAirGapped(t *testing.T) {
+	g := NewWithT(t)
+
+	config, err := cloudinit.NewJoinControlPlane(cloudinit.JoinControlPlaneInput{
+		BaseUserData: cloudinit.BaseUserData{
+			KubernetesVersion: "v1.30.0",
+			BootCommands:      []string{"bootcmd"},
+			PreRunCommands:    []string{"prerun1", "prerun2"},
+			PostRunCommands:   []string{"postrun1", "postrun2"},
+			AirGapped:         true,
+		},
+		JoinToken: "test-token",
+	})
+
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// Verify the run commands is missing install.sh script.
+	g.Expect(config.RunCommands).NotTo(ContainElement("/capi/scripts/install.sh"))
 }

--- a/pkg/cloudinit/controlplane_join_test.go
+++ b/pkg/cloudinit/controlplane_join_test.go
@@ -49,7 +49,7 @@ func TestNewJoinControlPlane(t *testing.T) {
 	}))
 
 	// NOTE (mateoflorido): Keep this test in sync with the expected paths in the controlplane_join.go file.
-	expectedPaths := []interface{}{
+	g.Expect(config.WriteFiles).To(ConsistOf(
 		HaveField("Path", "/capi/scripts/install.sh"),
 		HaveField("Path", "/capi/scripts/bootstrap.sh"),
 		HaveField("Path", "/capi/scripts/load-images.sh"),
@@ -63,9 +63,7 @@ func TestNewJoinControlPlane(t *testing.T) {
 		HaveField("Path", "/capi/etc/join-token"),
 		HaveField("Path", "/capi/etc/snap-track"),
 		HaveField("Path", "/tmp/file"),
-	}
-
-	g.Expect(config.WriteFiles).To(ConsistOf(expectedPaths...), "Some /capi/scripts files are missing")
+	), "Some /capi/scripts files are missing")
 }
 
 func TestNewJoinControlPlaneInvalidVersionError(t *testing.T) {

--- a/pkg/cloudinit/worker_join_test.go
+++ b/pkg/cloudinit/worker_join_test.go
@@ -1,7 +1,6 @@
 package cloudinit_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -49,64 +48,24 @@ func TestNewJoinWorker(t *testing.T) {
 		"postrun2",
 	}))
 
-	// Define the expected files to write with their content, path, permissions, and owner.
-	expectedWriteFiles := []cloudinit.File{
-		{
-			Path:        "/tmp/file",
-			Content:     "test file",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/config.yaml",
-			Content:     "### config file ###",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/microcluster-address",
-			Content:     "10.0.0.10:8080",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/snap-track",
-			Content:     "1.30-classic/stable",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
-		{
-			Path:        "/capi/etc/join-token",
-			Content:     "test-token",
-			Permissions: "0400",
-			Owner:       "root:root",
-		},
+	// NOTE (mateoflorido): Keep this test in sync with the expected paths in the worker_join.go file.
+	expectedPaths := []interface{}{
+		HaveField("Path", "/capi/scripts/install.sh"),
+		HaveField("Path", "/capi/scripts/bootstrap.sh"),
+		HaveField("Path", "/capi/scripts/load-images.sh"),
+		HaveField("Path", "/capi/scripts/join-cluster.sh"),
+		HaveField("Path", "/capi/scripts/wait-apiserver-ready.sh"),
+		HaveField("Path", "/capi/scripts/deploy-manifests.sh"),
+		HaveField("Path", "/capi/scripts/configure-token.sh"),
+		HaveField("Path", "/capi/scripts/create-sentinel-bootstrap.sh"),
+		HaveField("Path", "/capi/etc/config.yaml"),
+		HaveField("Path", "/capi/etc/microcluster-address"),
+		HaveField("Path", "/capi/etc/join-token"),
+		HaveField("Path", "/capi/etc/snap-track"),
+		HaveField("Path", "/tmp/file"),
 	}
 
-	scriptFiles := map[string]string{
-		"./scripts/install.sh":                   "/capi/scripts/install.sh",
-		"./scripts/bootstrap.sh":                 "/capi/scripts/bootstrap.sh",
-		"./scripts/load-images.sh":               "/capi/scripts/load-images.sh",
-		"./scripts/join-cluster.sh":              "/capi/scripts/join-cluster.sh",
-		"./scripts/wait-apiserver-ready.sh":      "/capi/scripts/wait-apiserver-ready.sh",
-		"./scripts/deploy-manifests.sh":          "/capi/scripts/deploy-manifests.sh",
-		"./scripts/configure-token.sh":           "/capi/scripts/configure-token.sh",
-		"./scripts/create-sentinel-bootstrap.sh": "/capi/scripts/create-sentinel-bootstrap.sh",
-	}
-
-	// Read the content of each script file and append it to the expected write files.
-	for relativePath, scriptPath := range scriptFiles {
-		content, err := os.ReadFile(relativePath)
-		g.Expect(err).NotTo(HaveOccurred())
-		expectedWriteFiles = append(expectedWriteFiles, cloudinit.File{
-			Path:        scriptPath,
-			Content:     string(content),
-			Permissions: "0500",
-			Owner:       "root:root",
-		})
-	}
-
-	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
+	g.Expect(config.WriteFiles).To(ConsistOf(expectedPaths...), "Some /capi/scripts files are missing")
 }
 
 func TestNewJoinWorkerInvalidVersionError(t *testing.T) {

--- a/pkg/cloudinit/worker_join_test.go
+++ b/pkg/cloudinit/worker_join_test.go
@@ -109,7 +109,7 @@ func TestNewJoinWorker(t *testing.T) {
 	g.Expect(config.WriteFiles).To(ConsistOf(expectedWriteFiles))
 }
 
-func TestNewJoinWorkerError(t *testing.T) {
+func TestNewJoinWorkerInvalidVersionError(t *testing.T) {
 	g := NewWithT(t)
 
 	_, err := cloudinit.NewJoinWorker(cloudinit.JoinWorkerInput{

--- a/pkg/cloudinit/worker_join_test.go
+++ b/pkg/cloudinit/worker_join_test.go
@@ -49,7 +49,7 @@ func TestNewJoinWorker(t *testing.T) {
 	}))
 
 	// NOTE (mateoflorido): Keep this test in sync with the expected paths in the worker_join.go file.
-	expectedPaths := []interface{}{
+	g.Expect(config.WriteFiles).To(ConsistOf(
 		HaveField("Path", "/capi/scripts/install.sh"),
 		HaveField("Path", "/capi/scripts/bootstrap.sh"),
 		HaveField("Path", "/capi/scripts/load-images.sh"),
@@ -63,9 +63,7 @@ func TestNewJoinWorker(t *testing.T) {
 		HaveField("Path", "/capi/etc/join-token"),
 		HaveField("Path", "/capi/etc/snap-track"),
 		HaveField("Path", "/tmp/file"),
-	}
-
-	g.Expect(config.WriteFiles).To(ConsistOf(expectedPaths...), "Some /capi/scripts files are missing")
+	), "Some /capi/scripts files are missing")
 }
 
 func TestNewJoinWorkerInvalidVersionError(t *testing.T) {


### PR DESCRIPTION
## Overview
Add unit tests for the `cloudinit` package.
## Rationale
These unit tests aim to validate the following aspects of cloudinit configurations:
- Expected commands within each config.
 - Expected files within configs for:
   - Initializing control planes
   - Joining new control planes
   - Joining new workers