### PR TITLE
Handle Go version used to build image

### DIFF
--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -43,10 +43,8 @@ RUN apt-get update \
 
 ## NOTE(neoaggelos): Go version used to build components
 ## !!!IMPORTANT!!! Keep up to date with "snapcraft.yaml:parts.build-deps.build-snaps.go"
-RUN wget https://go.dev/dl/go1.22.4.linux-amd64.tar.gz \
-    && mkdir -p /usr/local/go122 \
-    && tar -C /usr/local/go122 -xzf go1.22.4.linux-amd64.tar.gz \
-    && ln -s /usr/local/go122/go/bin/go /usr/local/bin/go
+ADD install-go.sh
+RUN install-go.sh 1.22 && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 ## Prepare build environment
 ENV SNAPCRAFT_PART_INSTALL=/out

--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -48,13 +48,6 @@ RUN wget https://go.dev/dl/go1.22.4.linux-amd64.tar.gz \
     && tar -C /usr/local/go122 -xzf go1.22.4.linux-amd64.tar.gz \
     && ln -s /usr/local/go122/go/bin/go /usr/local/bin/go
 
-## NOTE(neoaggelos): runc needs Go 1.21 to build
-## !!!IMPORTANT!!! Drop this after runc 1.1.13 is released https://github.com/opencontainers/runc/issues/4233#issuecomment-2155883159
-RUN wget https://go.dev/dl/go1.21.11.linux-amd64.tar.gz \
-    && mkdir -p /usr/local/go121 \
-    && tar -C /usr/local/go121 -xzf go1.21.11.linux-amd64.tar.gz \
-    && ln -s /usr/local/go121/go/bin/go /usr/local/bin/go_121
-
 ## Prepare build environment
 ENV SNAPCRAFT_PART_INSTALL=/out
 RUN mkdir /out /build -p

--- a/templates/docker/install-go.sh
+++ b/templates/docker/install-go.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -xe
+
+# Author: Angelos Kolaitis <angelos.kolaitis@canonical.com>
+#
+# Usage:
+#    $ install-go.sh 1.22
+#
+# Description: Download latest go version and install under /usr/local/go
+
+VERSION="$1"
+
+fname="$(curl -s https://go.dev/dl/ | grep -o "go$VERSION.*.linux-amd64.tar.gz" | head -1)"
+wget "https://go.dev/dl/$fname"
+tar -C /usr/local -xvzf "$fname"
+rm "$fname"


### PR DESCRIPTION
## Summary

Requires https://github.com/canonical/k8s-snap/pull/559

## Changes

- Do not pull go1.21
- Automatically pick latest Go version from 1.22 track 