### PR TITLE
disable k8s node cleanup and let CAPI handle it

### DIFF
--- a/pkg/ck8s/api/annotations.go
+++ b/pkg/ck8s/api/annotations.go
@@ -1,0 +1,8 @@
+package apiv1
+
+const (
+	// AnnotationSkipCleanupKubernetesNodeOnRemove if set, only the microcluster & file cleanup is done.
+	// This is useful, if an external controller (e.g. CAPI) is responsible for the Kubernetes node life cycle.
+	// By default, the Kubernetes node is removed by k8sd if a node is removed from the cluster.
+	AnnotationSkipCleanupKubernetesNodeOnRemove = "k8sd/v1alpha/lifecycle/skip-cleanup-kubernetes-node-on-remove"
+)

--- a/pkg/ck8s/api/bootstrap_config.go
+++ b/pkg/ck8s/api/bootstrap_config.go
@@ -17,6 +17,7 @@ type BootstrapConfig struct {
 	DatastoreCACert     *string  `json:"datastore-ca-crt,omitempty" yaml:"datastore-ca-crt,omitempty"`
 	DatastoreClientCert *string  `json:"datastore-client-crt,omitempty" yaml:"datastore-client-crt,omitempty"`
 	DatastoreClientKey  *string  `json:"datastore-client-key,omitempty" yaml:"datastore-client-key,omitempty"`
+	ShouldRemoveK8sNode *bool    `json:"should-remove-k8s-node,omitempty" yaml:"should-remove-k8s-node,omitempty"`
 
 	// Seed configuration for certificates
 	ExtraSANs []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`

--- a/pkg/ck8s/api/bootstrap_config.go
+++ b/pkg/ck8s/api/bootstrap_config.go
@@ -17,7 +17,6 @@ type BootstrapConfig struct {
 	DatastoreCACert     *string  `json:"datastore-ca-crt,omitempty" yaml:"datastore-ca-crt,omitempty"`
 	DatastoreClientCert *string  `json:"datastore-client-crt,omitempty" yaml:"datastore-client-crt,omitempty"`
 	DatastoreClientKey  *string  `json:"datastore-client-key,omitempty" yaml:"datastore-client-key,omitempty"`
-	ShouldRemoveK8sNode *bool    `json:"should-remove-k8s-node,omitempty" yaml:"should-remove-k8s-node,omitempty"`
 
 	// Seed configuration for certificates
 	ExtraSANs []string `json:"extra-sans,omitempty" yaml:"extra-sans,omitempty"`

--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -78,12 +78,13 @@ func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.Bootstrap
 		out.DatastoreServers = cfg.DatastoreServers
 	}
 
-	// CAPI manages the lifecycle of the Kubernetes node.
-	// Hence, k8s-snap should only clean up microcluster and files on upgrades.
-	out.ShouldRemoveK8sNode = ptr.To(false)
-
 	// annotations
 	out.ClusterConfig.Annotations = cfg.InitConfig.Annotations
+
+	// Since CAPI handles the lifecycle management of Kubernetes nodes, k8s-snap should only focus on
+	// cleaning up microcluster and files during upgrades. This is essential for CAPI to function correctly.
+	// Therefore, instead of relying on the user to set this annotation in the initConfig, we hardcode it here.
+	out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove] = "true"
 
 	// features
 	out.ClusterConfig.DNS.Enabled = ptr.To(cfg.InitConfig.GetEnableDefaultDNS())

--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -78,6 +78,10 @@ func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.Bootstrap
 		out.DatastoreServers = cfg.DatastoreServers
 	}
 
+	// CAPI manages the lifecycle of the Kubernetes node.
+	// Hence, k8s-snap should only clean up microcluster and files on upgrades.
+	out.ShouldRemoveK8sNode = ptr.To(false)
+
 	// annotations
 	out.ClusterConfig.Annotations = cfg.InitConfig.Annotations
 

--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -82,9 +82,10 @@ func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.Bootstrap
 	out.ClusterConfig.Annotations = cfg.InitConfig.Annotations
 
 	// Since CAPI handles the lifecycle management of Kubernetes nodes, k8s-snap should only focus on
-	// cleaning up microcluster and files during upgrades. This is essential for CAPI to function correctly.
-	// Therefore, instead of relying on the user to set this annotation in the initConfig, we hardcode it here.
-	out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove] = "true"
+	// cleaning up microcluster and files during upgrades.
+	if _, ok := out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove]; !ok {
+		out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove] = "true"
+	}
 
 	// features
 	out.ClusterConfig.DNS.Enabled = ptr.To(cfg.InitConfig.GetEnableDefaultDNS())


### PR DESCRIPTION
This pull request addresses an issue where nodes are not properly drained in Cluster API before upgrades. The current CK8s remove hook removes the node from the Kubernetes cluster, which conflicts with the CAPI core controllers responsible for node removal within the CAPI context. As a result, when our controllers remove the node, the core controller loses track and only removes the resource reference in the management cluster.

This PR disables the Kubernetes node removal in the k8s-snap.

Requires https://github.com/canonical/k8s-snap/pull/577 to be merged. See there for more details.