### PR TITLE
Add dualstack template

### DIFF
--- a/templates/docker/cluster-template-dualstack.yaml
+++ b/templates/docker/cluster-template-dualstack.yaml
@@ -1,0 +1,99 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 10.1.0.0/16
+      - fd00::/108
+    services:
+      cidrBlocks:
+      - 10.152.0.0/16
+      - fd01::/108
+    serviceDomain: cluster.local
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: CK8sControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: CK8sControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  machineTemplate:
+    infrastructureTemplate:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  spec:
+    airGapped: true
+    controlPlane:
+      extraKubeAPIServerArgs:
+        --anonymous-auth: "true"
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      customImage: ${KIND_IMAGE}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-worker-md-0
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  template:
+    spec:
+      version: ${KUBERNETES_VERSION}
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: CK8sConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      customImage: ${KIND_IMAGE}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: CK8sConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      airGapped: true


### PR DESCRIPTION
Adds a template to use for dualstack clusters.

The following steps where done to test with CAPD:

1. Create a dualstack network   
   `sudo docker network create kind –ipv6 --driver=bridge -o com.docker.network.bridge.enable_ip_masquerade=true`  
   (note that docker will ALWAYS use IPv4) \-\> `--ipv6` \== dualstack  
1. Generate cluster yaml from `templates/docker/cluster-template-dualstack.yaml`

	

```
KIND_IMAGE=k8s-snap:dev CONTROL_PLANE_MACHINE_COUNT=3 WORKER_MACHINE_COUNT=3 clusterctl generate cluster c1 --from ./templates/docker/cluster-template-dualstack.yaml  --kubernetes-version v1.30.3 > c1.yaml
```

1. Wait until all nodes/pods are up on workload cluster  
1. Deploy `nginx-dualstack.yaml` on the cluster  
   `k8s kubectl apply -f https://raw.githubusercontent.com/canonical/k8s-snap/main/tests/integration/templates/nginx-dualstack.yaml`  
1. Get IPv6 of service:

```
root@c1-control-plane-x2mk9:/# k8s kubectl describe svc nginx-dualstack | grep IPs
IPs:                      10.152.98.81,fd01::506a
```

1. Try to curl nginx endpoint

```
root@c1-control-plane-x2mk9:/# curl http://\[fd01::506a\]/
<!DOCTYPE html>
<html>
<head>
<title>Kubernetes IPv6 nginx</title> 
<style>
    body {
        width: 35em;
        margin: 0 auto;
        font-family: Tahoma, Verdana, Arial, sans-serif;
    }
</style>
</head>
<body>
<h1>Welcome to nginx on <span style="color:  #C70039">IPv6</span> Kubernetes!</h1>
<p>Pod: nginxdualstack-77676679b6-7rpmt</p>
</body>
</html>


```