### PR TITLE
use hardcoded Go version to get go from go.dev/dl in Dockerfile

### DIFF
--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
 ## NOTE(neoaggelos): Go version used to build components
 ## !!!IMPORTANT!!! Keep up to date with "snapcraft.yaml:parts.build-deps.build-snaps.go"
 ADD install-go.sh /
-RUN /install-go.sh 1.22 && ln -s /usr/local/go/bin/go /usr/local/bin/go
+RUN /install-go.sh && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 ## Prepare build environment
 ENV SNAPCRAFT_PART_INSTALL=/out

--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
 ## NOTE(neoaggelos): Go version used to build components
 ## !!!IMPORTANT!!! Keep up to date with "snapcraft.yaml:parts.build-deps.build-snaps.go"
 ADD install-go.sh /
-RUN /install-go.sh && ln -s /usr/local/go/bin/go /usr/local/bin/go
+RUN /install-go.sh 1.22.6 && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 ## Prepare build environment
 ENV SNAPCRAFT_PART_INSTALL=/out

--- a/templates/docker/install-go.sh
+++ b/templates/docker/install-go.sh
@@ -9,7 +9,7 @@
 
 VERSION="$1"
 
-fname="$(curl -s https://go.dev/dl/ | grep -o "go$VERSION.*.linux-amd64.tar.gz" | head -1)"
+fname="$(curl -s https://go.dev/dl/ | grep -oP "go$VERSION\.\d+\.linux-amd64\.tar\.gz" | head -1)"
 wget "https://go.dev/dl/$fname"
 tar -C /usr/local -xvzf "$fname"
 rm "$fname"

--- a/templates/docker/install-go.sh
+++ b/templates/docker/install-go.sh
@@ -3,11 +3,13 @@
 # Author: Angelos Kolaitis <angelos.kolaitis@canonical.com>
 #
 # Usage:
-#    $ install-go.sh $version
+#    $ install-go.sh 1.22.6
 #
 # Description: Download go version and install under /usr/local/go
 
 VERSION="$1"
-wget "https://go.dev/dl/go1.22.6.linux-amd64.tar.gz"
-tar -C /usr/local -xvzf "go1.22.6.linux-amd64.tar.gz"
-rm "go${VERSION}.linux-amd64.tar.gz"
+
+fname="go${VERSION}.linux-amd64.tar.gz"
+wget "https://go.dev/dl/${fname}"
+tar -C /usr/local -xvzf "${fname}"
+rm "${fname}"

--- a/templates/docker/install-go.sh
+++ b/templates/docker/install-go.sh
@@ -3,13 +3,10 @@
 # Author: Angelos Kolaitis <angelos.kolaitis@canonical.com>
 #
 # Usage:
-#    $ install-go.sh 1.22
+#    $ install-go.sh
 #
-# Description: Download latest go version and install under /usr/local/go
+# Description: Download go 1.22.6 and install under /usr/local/go
 
-VERSION="$1"
-
-fname="$(curl -s https://go.dev/dl/ | grep -oP "go$VERSION\.\d+\.linux-amd64\.tar\.gz" | head -1)"
-wget "https://go.dev/dl/$fname"
-tar -C /usr/local -xvzf "$fname"
-rm "$fname"
+wget "https://go.dev/dl/go1.22.6.linux-amd64.tar.gz"
+tar -C /usr/local -xvzf "go1.22.6.linux-amd64.tar.gz"
+rm "go1.22.6.linux-amd64.tar.gz"

--- a/templates/docker/install-go.sh
+++ b/templates/docker/install-go.sh
@@ -3,10 +3,11 @@
 # Author: Angelos Kolaitis <angelos.kolaitis@canonical.com>
 #
 # Usage:
-#    $ install-go.sh
+#    $ install-go.sh $version
 #
-# Description: Download go 1.22.6 and install under /usr/local/go
+# Description: Download go version and install under /usr/local/go
 
+VERSION="$1"
 wget "https://go.dev/dl/go1.22.6.linux-amd64.tar.gz"
 tar -C /usr/local -xvzf "go1.22.6.linux-amd64.tar.gz"
-rm "go1.22.6.linux-amd64.tar.gz"
+rm "go${VERSION}.linux-amd64.tar.gz"


### PR DESCRIPTION
old pattern could result in the following match which would cause a 404 during a docker build:

❯ curl -s https://go.dev/dl/ | grep -o "go1.22.*.linux-amd64.tar.gz"
go1.22.6.linux-amd64.tar.gz">go1.22.6.linux-amd64.tar.gz