### PR TITLE
Allow setting the node name in CK8sConfigTemplate

### DIFF
--- a/bootstrap/api/v1beta2/ck8sconfig_types.go
+++ b/bootstrap/api/v1beta2/ck8sconfig_types.go
@@ -58,6 +58,12 @@ type CK8sConfigSpec struct {
 	// CK8sInitConfig is configuration for the initializing the cluster features.
 	// +optional
 	InitConfig CK8sInitConfiguration `json:"initConfig,omitempty"`
+
+	// NodeName is the name to use for the kubelet of this node. It is needed for clouds
+	// where the cloud-provider has specific pre-requisites about the node names. It is
+	// typically set in Jinja template form, e.g."{{ ds.meta_data.local_hostname }}".
+	// +optional
+	NodeName string `json:"nodeName,omitempty"`
 }
 
 // IsEtcdManaged returns true if the control plane is using k8s-dqlite.

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
@@ -192,6 +192,12 @@ spec:
                       the default CNI.
                     type: boolean
                 type: object
+              nodeName:
+                description: |-
+                  NodeName is the name to use for the kubelet of this node. It is needed for clouds
+                  where the cloud-provider has specific pre-requisites about the node names. It is
+                  typically set in Jinja template form, e.g."{{ ds.meta_data.local_hostname }}".
+                type: string
               postRunCommands:
                 description: PostRunCommands specifies extra commands to run in cloud-init
                   after k8s-snap setup runs.

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
@@ -201,6 +201,12 @@ spec:
                               enable the default CNI.
                             type: boolean
                         type: object
+                      nodeName:
+                        description: |-
+                          NodeName is the name to use for the kubelet of this node. It is needed for clouds
+                          where the cloud-provider has specific pre-requisites about the node names. It is
+                          typically set in Jinja template form, e.g."{{ ds.meta_data.local_hostname }}".
+                        type: string
                       postRunCommands:
                         description: PostRunCommands specifies extra commands to run
                           in cloud-init after k8s-snap setup runs.

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -258,6 +258,7 @@ func (r *CK8sConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 			MicroclusterAddress: scope.Config.Spec.ControlPlaneConfig.MicroclusterAddress,
 			MicroclusterPort:    microclusterPort,
 			AirGapped:           scope.Config.Spec.AirGapped,
+			NodeName:            scope.Config.Spec.NodeName,
 		},
 		JoinToken: joinToken,
 	}
@@ -330,6 +331,7 @@ func (r *CK8sConfigReconciler) joinWorker(ctx context.Context, scope *Scope) err
 			MicroclusterAddress: scope.Config.Spec.ControlPlaneConfig.MicroclusterAddress,
 			MicroclusterPort:    microclusterPort,
 			AirGapped:           scope.Config.Spec.AirGapped,
+			NodeName:            scope.Config.Spec.NodeName,
 		},
 		JoinToken: joinToken,
 	}
@@ -514,6 +516,7 @@ func (r *CK8sConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 			ConfigFileContents:  string(initConfig),
 			MicroclusterAddress: scope.Config.Spec.ControlPlaneConfig.MicroclusterAddress,
 			MicroclusterPort:    microclusterPort,
+			NodeName:            scope.Config.Spec.NodeName,
 			AirGapped:           scope.Config.Spec.AirGapped,
 		},
 		Token:              *token,

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
@@ -389,6 +389,12 @@ spec:
                           the default CNI.
                         type: boolean
                     type: object
+                  nodeName:
+                    description: |-
+                      NodeName is the name to use for the kubelet of this node. It is needed for clouds
+                      where the cloud-provider has specific pre-requisites about the node names. It is
+                      typically set in Jinja template form, e.g."{{ ds.meta_data.local_hostname }}".
+                    type: string
                   postRunCommands:
                     description: PostRunCommands specifies extra commands to run in
                       cloud-init after k8s-snap setup runs.

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
@@ -366,6 +366,12 @@ spec:
                                   to enable the default CNI.
                                 type: boolean
                             type: object
+                          nodeName:
+                            description: |-
+                              NodeName is the name to use for the kubelet of this node. It is needed for clouds
+                              where the cloud-provider has specific pre-requisites about the node names. It is
+                              typically set in Jinja template form, e.g."{{ ds.meta_data.local_hostname }}".
+                            type: string
                           postRunCommands:
                             description: PostRunCommands specifies extra commands
                               to run in cloud-init after k8s-snap setup runs.

--- a/pkg/cloudinit/common.go
+++ b/pkg/cloudinit/common.go
@@ -28,6 +28,8 @@ type BaseUserData struct {
 	MicroclusterAddress string
 	// MicroclusterPort is the port to use for microcluster.
 	MicroclusterPort int
+	// NodeName is the name of the node to set on microcluster.
+	NodeName string
 }
 
 func NewBaseCloudConfig(data BaseUserData) (CloudConfig, error) {
@@ -64,6 +66,12 @@ func NewBaseCloudConfig(data BaseUserData) (CloudConfig, error) {
 			File{
 				Path:        "/capi/etc/microcluster-address",
 				Content:     makeMicroclusterAddress(data.MicroclusterAddress, data.MicroclusterPort),
+				Permissions: "0400",
+				Owner:       "root:root",
+			},
+			File{
+				Path:        "/capi/etc/node-name",
+				Content:     data.NodeName,
 				Permissions: "0400",
 				Owner:       "root:root",
 			},

--- a/pkg/cloudinit/scripts/bootstrap.sh
+++ b/pkg/cloudinit/scripts/bootstrap.sh
@@ -6,8 +6,9 @@
 ## - /capi/etc/config.yaml is a valid bootstrap configuration file
 
 address="$(cat /capi/etc/microcluster-address)"
+name="$(cat /capi/etc/node-name)"
 config_file="/capi/etc/config.yaml"
 
 if [ ! -f /etc/kubernetes/pki/ca.crt ]; then
-  k8s bootstrap --address "${address}" --file "${config_file}"
+  k8s bootstrap --name "${name}" --address "${address}" --file "${config_file}"
 fi

--- a/pkg/cloudinit/scripts/join-cluster.sh
+++ b/pkg/cloudinit/scripts/join-cluster.sh
@@ -6,7 +6,8 @@
 ## - /capi/etc/join-token is a valid join token
 
 address="$(cat /capi/etc/microcluster-address)"
+name="$(cat /capi/etc/node-name)"
 config_file="/capi/etc/config.yaml"
 token="$(cat /capi/etc/join-token)"
 
-k8s join-cluster "${token}" --address "${address}" --file "${config_file}"
+k8s join-cluster "${token}" --name "${name}" --address "${address}" --file "${config_file}"


### PR DESCRIPTION
### Summary

Some cloud providers (e.g. AWS) require that the hostname be set to a specific value, typically `{{ ds.meta_data.local_hostname }}`.

Allow setting this field in the template, and seed this into the generated cloud-init.

### Note

`{{ ds.meta_data.local_hostname }}` will be passed to the cloud-init, then will be replaced with the desired value when Jinja renders it on the local node.