### PR TITLE
Use Node name instead of Machine name on removal

### DIFF
--- a/pkg/ck8s/workload_cluster.go
+++ b/pkg/ck8s/workload_cluster.go
@@ -231,8 +231,9 @@ func (w *Workload) requestJoinToken(ctx context.Context, name string, worker boo
 
 func (w *Workload) RemoveMachineFromCluster(ctx context.Context, machine *clusterv1.Machine) error {
 	if machine == nil {
-		return fmt.Errorf("machine is nil")
-	} else if machine.Status.NodeRef == nil {
+		return fmt.Errorf("machine object is not set")
+	}
+	if machine.Status.NodeRef == nil {
 		return fmt.Errorf("machine %s has no node reference", machine.Name)
 	}
 


### PR DESCRIPTION
# Summary
This PR fixes the issue with CAPI rolling upgrades. The problem was that we were passing the wrong `node-name` to k8sd `remove-node` endpoint. 

# Description
CAPI rolling upgrades were failing, we narrowed down the problem, figured that the node removal process is not happening as expected (i.e. you can reproduce the problem by scaling down the control plane replicas of the workload cluster). Finally it was evident that the `/capi/remove-node` endpoint of k8sd was returning an error indicating that it can not find the node it was called to delete. That is because we were passing the `machine.Name` to k8sd `/capi/remove-node` endpoint, while as can be seen in the output of `kubectl get nodes` (of the workload cluster), we need to pass the node name.   