### PR TITLE
Add join token to SANs

### DIFF
--- a/pkg/cloudinit/controlplane_join.go
+++ b/pkg/cloudinit/controlplane_join.go
@@ -19,7 +19,7 @@ package cloudinit
 import (
 	"fmt"
 
-	apiv1 "github.com/canonical/cluster-api-k8s/pkg/ck8s/api"
+	apiv1 "github.com/canonical/k8s-snap-api/api/v1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -70,7 +70,7 @@ func NewJoinControlPlane(input JoinControlPlaneInput) (CloudConfig, error) {
 // This is required because the token name and kubelet name diverge in the CAPI context.
 // See https://github.com/canonical/k8s-snap/pull/629 for more details.
 func addJoinTokenToExtraSANsConfig(input JoinControlPlaneInput) (JoinControlPlaneInput, error) {
-	var joinConfig apiv1.ControlPlaneNodeJoinConfig
+	var joinConfig apiv1.ControlPlaneJoinConfig
 	err := yaml.Unmarshal([]byte(input.BaseUserData.ConfigFileContents), &joinConfig)
 	if err != nil {
 		return JoinControlPlaneInput{}, fmt.Errorf("failed to parse config file: %w", err)

--- a/pkg/cloudinit/controlplane_join.go
+++ b/pkg/cloudinit/controlplane_join.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package cloudinit
 
-import "fmt"
+import (
+	"fmt"
+
+	apiv1 "github.com/canonical/cluster-api-k8s/pkg/ck8s/api"
+	"gopkg.in/yaml.v2"
+)
 
 // JoinControlPlaneInput defines the context to generate a join controlplane instance user data.
 type JoinControlPlaneInput struct {
@@ -27,6 +32,11 @@ type JoinControlPlaneInput struct {
 
 // NewJoinControlPlane returns the user data string to be used on a controlplane instance.
 func NewJoinControlPlane(input JoinControlPlaneInput) (CloudConfig, error) {
+	input, err := addJoinTokenToExtraSANsConfig(input)
+	if err != nil {
+		return CloudConfig{}, fmt.Errorf("failed to add join token to ExtraSANs: %w", err)
+	}
+
 	config, err := NewBaseCloudConfig(input.BaseUserData)
 	if err != nil {
 		return CloudConfig{}, fmt.Errorf("failed to generate base cloud-config: %w", err)
@@ -54,4 +64,27 @@ func NewJoinControlPlane(input JoinControlPlaneInput) (CloudConfig, error) {
 	config.RunCommands = append(config.RunCommands, input.PostRunCommands...)
 
 	return config, nil
+}
+
+// addJoinTokenToExtraSANsConfig adds the JoinToken to the ExtraSANs field in the control plane node join config.
+// This is required because the token name and kubelet name diverge in the CAPI context.
+// See https://github.com/canonical/k8s-snap/pull/629 for more details.
+func addJoinTokenToExtraSANsConfig(input JoinControlPlaneInput) (JoinControlPlaneInput, error) {
+	var joinConfig apiv1.ControlPlaneNodeJoinConfig
+	err := yaml.Unmarshal([]byte(input.BaseUserData.ConfigFileContents), &joinConfig)
+	if err != nil {
+		return JoinControlPlaneInput{}, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if joinConfig.ExtraSANS == nil {
+		joinConfig.ExtraSANS = []string{}
+	}
+
+	joinConfig.ExtraSANS = append(joinConfig.ExtraSANS, input.JoinToken)
+	updatedConfig, err := yaml.Marshal(joinConfig)
+	if err != nil {
+		return JoinControlPlaneInput{}, fmt.Errorf("failed to marshal updated config: %w", err)
+	}
+	input.BaseUserData.ConfigFileContents = string(updatedConfig)
+	return input, nil
 }


### PR DESCRIPTION
This PR adds the token name to the extraSANs to make the microcluster token verification happy.
See https://github.com/canonical/k8s-snap/pull/629 for more context on why we need this.

### Testing

Setup a test cluster with docker containers build from 
The cluster comes up and nodes are joining:
```
NAME                                                READY  SEVERITY  REASON  SINCE  MESSAGE
Cluster/c1                                          True                     20m
├─ClusterInfrastructure - DockerCluster/c1          True                     25m
├─ControlPlane - CK8sControlPlane/c1-control-plane  True                     20m
│ └─3 Machines...                                   True                     22m    See c1-control-plane-jrgpj, c1-control-plane-nl86p, ...
└─Workers
  └─MachineDeployment/c1-worker-md-0                True                     21m
    └─3 Machines...                                 True                     23m    See c1-worker-md-0-lgsvj-8945w, c1-worker-md-0-lgsvj-ptqmh, ...
```