### PR TITLE
Fix annotation, Skip nil response

### DIFF
--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -83,10 +83,12 @@ func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.Bootstrap
 
 	// Since CAPI handles the lifecycle management of Kubernetes nodes, k8s-snap should only focus on
 	// cleaning up microcluster and files during upgrades.
-	if out.ClusterConfig.Annotations != nil {
-		if _, ok := out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove]; !ok {
-			out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove] = "true"
-		}
+	if out.ClusterConfig.Annotations == nil {
+		out.ClusterConfig.Annotations = map[string]string{}
+	}
+
+	if _, ok := out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove]; !ok {
+		out.ClusterConfig.Annotations[apiv1.AnnotationSkipCleanupKubernetesNodeOnRemove] = "true"
 	}
 
 	// features

--- a/pkg/ck8s/workload_cluster.go
+++ b/pkg/ck8s/workload_cluster.go
@@ -289,7 +289,7 @@ func (w *Workload) doK8sdRequest(ctx context.Context, method, endpoint string, r
 	if responseBody.Error != "" {
 		return fmt.Errorf("k8sd request failed: %s", responseBody.Error)
 	}
-	if responseBody.Metadata == nil {
+	if responseBody.Metadata == nil || response == nil {
 		// Nothing to decode
 		return nil
 	}


### PR DESCRIPTION
We use `SkipCleanup` annotation to make sure k8sd does not remove the actual k8s node when calling `/x/capi/remove-node` endpoint so that CAPI core provider can take care of that. This PR makes sure the annotation is available in the cluster config everytime (currently we might end up not without the annotation).
Also there was a minor issue in the `doK8sdRequest` in which we tried to unmarshal metadata in a nil response.