### PR TITLE
rename max to maxDuration to fix predeclared lint

### DIFF
--- a/controlplane/controllers/remediation.go
+++ b/controlplane/controllers/remediation.go
@@ -373,7 +373,7 @@ func (r *CK8sControlPlaneReconciler) checkRetryLimits(log logr.Logger, machineTo
 	return remediationInProgressData, true, nil
 }
 
-// maxDuration calculates the maximum duration.
+// maxDuration returns the longer of two time.Duration values.
 func maxDuration(x, y time.Duration) time.Duration {
 	if x < y {
 		return y

--- a/controlplane/controllers/remediation.go
+++ b/controlplane/controllers/remediation.go
@@ -326,7 +326,7 @@ func (r *CK8sControlPlaneReconciler) checkRetryLimits(log logr.Logger, machineTo
 	// NOTE: this could potentially lead to executing more retries than expected or to executing retries before than
 	// expected, but this is considered acceptable when the system recovers from someone/something changes or deletes
 	// the RemediationForAnnotation on Machines.
-	lastRemediationTime := reconciliationTime.Add(-2 * max(minHealthyPeriod, retryPeriod))
+	lastRemediationTime := reconciliationTime.Add(-2 * clamp(minHealthyPeriod, retryPeriod))
 	if !lastRemediationData.Timestamp.IsZero() {
 		lastRemediationTime = lastRemediationData.Timestamp.Time
 	}
@@ -373,8 +373,8 @@ func (r *CK8sControlPlaneReconciler) checkRetryLimits(log logr.Logger, machineTo
 	return remediationInProgressData, true, nil
 }
 
-// max calculates the maximum duration.
-func max(x, y time.Duration) time.Duration {
+// clamp calculates the maximum duration.
+func clamp(x, y time.Duration) time.Duration {
 	if x < y {
 		return y
 	}

--- a/controlplane/controllers/remediation.go
+++ b/controlplane/controllers/remediation.go
@@ -326,7 +326,7 @@ func (r *CK8sControlPlaneReconciler) checkRetryLimits(log logr.Logger, machineTo
 	// NOTE: this could potentially lead to executing more retries than expected or to executing retries before than
 	// expected, but this is considered acceptable when the system recovers from someone/something changes or deletes
 	// the RemediationForAnnotation on Machines.
-	lastRemediationTime := reconciliationTime.Add(-2 * clamp(minHealthyPeriod, retryPeriod))
+	lastRemediationTime := reconciliationTime.Add(-2 * maxDuration(minHealthyPeriod, retryPeriod))
 	if !lastRemediationData.Timestamp.IsZero() {
 		lastRemediationTime = lastRemediationData.Timestamp.Time
 	}
@@ -373,8 +373,8 @@ func (r *CK8sControlPlaneReconciler) checkRetryLimits(log logr.Logger, machineTo
 	return remediationInProgressData, true, nil
 }
 
-// clamp calculates the maximum duration.
-func clamp(x, y time.Duration) time.Duration {
+// maxDuration calculates the maximum duration.
+func maxDuration(x, y time.Duration) time.Duration {
 	if x < y {
 		return y
 	}


### PR DESCRIPTION
Fixes: `controlplane/controllers/remediation.go:377:6: function max has same name as predeclared identifier (predeclared)`