### PR TITLE
Use in-place upgrade release annotation if present

### DIFF
--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -401,29 +401,31 @@ func (r *CK8sConfigReconciler) resolveInPlaceUpgradeRelease(machine *clusterv1.M
 	mAnnotations := machine.GetAnnotations()
 
 	if mAnnotations != nil {
-		val, ok := mAnnotations[bootstrapv1.InPlaceUpgradeReleaseAnnotation]
-		if ok {
-			optionKv := strings.Split(val, "=")
+		return cloudinit.SnapInstallData{}
+	}
 
-			switch optionKv[0] {
-			case "channel":
-				return cloudinit.SnapInstallData{
-					Option: cloudinit.InstallOptionChannel,
-					Value:  optionKv[1],
-				}
-			case "revision":
-				return cloudinit.SnapInstallData{
-					Option: cloudinit.InstallOptionRevision,
-					Value:  optionKv[1],
-				}
-			case "localPath":
-				return cloudinit.SnapInstallData{
-					Option: cloudinit.InstallOptionLocalPath,
-					Value:  optionKv[1],
-				}
-			default:
-				r.Log.Info("Unknown in-place upgrade release option, ignoring", "option", optionKv[0])
+	val, ok := mAnnotations[bootstrapv1.InPlaceUpgradeReleaseAnnotation]
+	if ok {
+		optionKv := strings.Split(val, "=")
+
+		switch optionKv[0] {
+		case "channel":
+			return cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionChannel,
+				Value:  optionKv[1],
 			}
+		case "revision":
+			return cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionRevision,
+				Value:  optionKv[1],
+			}
+		case "localPath":
+			return cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionLocalPath,
+				Value:  optionKv[1],
+			}
+		default:
+			r.Log.Info("Unknown in-place upgrade release option, ignoring", "option", optionKv[0])
 		}
 	}
 

--- a/controlplane/controllers/ck8scontrolplane_controller.go
+++ b/controlplane/controllers/ck8scontrolplane_controller.go
@@ -699,7 +699,12 @@ func (r *CK8sControlPlaneReconciler) syncMachines(ctx context.Context, kcp *cont
 
 		patchHelper, err := patch.NewHelper(m, r.Client)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to create patch helper for machine: %w", err)
+		}
+
+		// Create a new map if machine has no annotations.
+		if m.Annotations == nil {
+			m.Annotations = map[string]string{}
 		}
 
 		// Set annotations

--- a/pkg/cloudinit/common.go
+++ b/pkg/cloudinit/common.go
@@ -12,7 +12,7 @@ import (
 type InstallOption string
 
 const (
-	InstallOptionChannel   InstallOption = "track"
+	InstallOptionChannel   InstallOption = "channel"
 	InstallOptionRevision  InstallOption = "revision"
 	InstallOptionLocalPath InstallOption = "local-path"
 )

--- a/pkg/cloudinit/controlplane_init_test.go
+++ b/pkg/cloudinit/controlplane_init_test.go
@@ -86,7 +86,7 @@ func TestNewInitControlPlane(t *testing.T) {
 		HaveField("Path", "/capi/etc/node-name"),
 		HaveField("Path", "/capi/etc/node-token"),
 		HaveField("Path", "/capi/etc/token"),
-		HaveField("Path", "/capi/etc/snap-track"),
+		HaveField("Path", "/capi/etc/snap-chanel"),
 		HaveField("Path", "/capi/manifests/00-k8sd-proxy.yaml"),
 		HaveField("Path", "/tmp/file"),
 	), "Some /capi/scripts files are missing")

--- a/pkg/cloudinit/controlplane_init_test.go
+++ b/pkg/cloudinit/controlplane_init_test.go
@@ -86,7 +86,7 @@ func TestNewInitControlPlane(t *testing.T) {
 		HaveField("Path", "/capi/etc/node-name"),
 		HaveField("Path", "/capi/etc/node-token"),
 		HaveField("Path", "/capi/etc/token"),
-		HaveField("Path", "/capi/etc/snap-chanel"),
+		HaveField("Path", "/capi/etc/snap-channel"),
 		HaveField("Path", "/capi/manifests/00-k8sd-proxy.yaml"),
 		HaveField("Path", "/tmp/file"),
 	), "Some /capi/scripts files are missing")

--- a/pkg/cloudinit/controlplane_init_test.go
+++ b/pkg/cloudinit/controlplane_init_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package cloudinit_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 
 	"github.com/canonical/cluster-api-k8s/pkg/cloudinit"
 )
@@ -120,4 +122,75 @@ func TestNewInitControlPlaneAirGapped(t *testing.T) {
 
 	// Verify the run commands is missing install.sh script.
 	g.Expect(config.RunCommands).NotTo(ContainElement("/capi/scripts/install.sh"))
+}
+
+func TestNewInitControlPlaneSnapInstall(t *testing.T) {
+	t.Run("DefaultSnapInstall", func(t *testing.T) {
+		g := NewWithT(t)
+
+		config, err := cloudinit.NewInitControlPlane(cloudinit.InitControlPlaneInput{
+			BaseUserData: cloudinit.BaseUserData{
+				KubernetesVersion: "v1.30.0",
+				BootCommands:      []string{"bootcmd"},
+				PreRunCommands:    []string{"prerun1", "prerun2"},
+				PostRunCommands:   []string{"postrun1", "postrun2"},
+			}})
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(config.WriteFiles).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Path":    Equal(fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionChannel)),
+			"Content": Equal("1.30-classic/stable"),
+		})))
+		g.Expect(config.WriteFiles).ToNot(ContainElement(HaveField("Path", fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionRevision))))
+		g.Expect(config.WriteFiles).ToNot(ContainElement(HaveField("Path", fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionLocalPath))))
+	})
+
+	tests := []struct {
+		name        string
+		snapInstall cloudinit.SnapInstallData
+	}{
+		{
+			name: "ChannelOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionChannel,
+				Value:  "v1.30/stable",
+			},
+		},
+		{
+			name: "RevisionOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionRevision,
+				Value:  "123",
+			},
+		},
+		{
+			name: "LocalPathOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionLocalPath,
+				Value:  "/path/to/k8s.snap",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			config, err := cloudinit.NewInitControlPlane(cloudinit.InitControlPlaneInput{
+				BaseUserData: cloudinit.BaseUserData{
+					KubernetesVersion: "v1.30.0",
+					SnapInstallData:   tt.snapInstall,
+					BootCommands:      []string{"bootcmd"},
+					PreRunCommands:    []string{"prerun1", "prerun2"},
+					PostRunCommands:   []string{"postrun1", "postrun2"},
+				}})
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(config.WriteFiles).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Path":    Equal(fmt.Sprintf("/capi/etc/snap-%s", tt.snapInstall.Option)),
+				"Content": Equal(tt.snapInstall.Value),
+			})))
+		})
+	}
 }

--- a/pkg/cloudinit/controlplane_join_test.go
+++ b/pkg/cloudinit/controlplane_join_test.go
@@ -67,7 +67,7 @@ func TestNewJoinControlPlane(t *testing.T) {
 		HaveField("Path", "/capi/etc/node-name"),
 		HaveField("Path", "/capi/etc/node-token"),
 		HaveField("Path", "/capi/etc/join-token"),
-		HaveField("Path", "/capi/etc/snap-track"),
+		HaveField("Path", "/capi/etc/snap-channel"),
 		HaveField("Path", "/tmp/file"),
 	), "Some /capi/scripts files are missing")
 }

--- a/pkg/cloudinit/controlplane_join_test.go
+++ b/pkg/cloudinit/controlplane_join_test.go
@@ -1,9 +1,11 @@
 package cloudinit_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 
 	"github.com/canonical/cluster-api-k8s/pkg/cloudinit"
 )
@@ -104,4 +106,75 @@ func TestNewJoinControlPlaneAirGapped(t *testing.T) {
 
 	// Verify the run commands is missing install.sh script.
 	g.Expect(config.RunCommands).NotTo(ContainElement("/capi/scripts/install.sh"))
+}
+
+func TestNewJoinControlPlaneSnapInstall(t *testing.T) {
+	t.Run("DefaultSnapInstall", func(t *testing.T) {
+		g := NewWithT(t)
+
+		config, err := cloudinit.NewJoinControlPlane(cloudinit.JoinControlPlaneInput{
+			BaseUserData: cloudinit.BaseUserData{
+				KubernetesVersion: "v1.30.0",
+				BootCommands:      []string{"bootcmd"},
+				PreRunCommands:    []string{"prerun1", "prerun2"},
+				PostRunCommands:   []string{"postrun1", "postrun2"},
+			}})
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(config.WriteFiles).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Path":    Equal(fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionChannel)),
+			"Content": Equal("1.30-classic/stable"),
+		})))
+		g.Expect(config.WriteFiles).ToNot(ContainElement(HaveField("Path", fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionRevision))))
+		g.Expect(config.WriteFiles).ToNot(ContainElement(HaveField("Path", fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionLocalPath))))
+	})
+
+	tests := []struct {
+		name        string
+		snapInstall cloudinit.SnapInstallData
+	}{
+		{
+			name: "ChannelOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionChannel,
+				Value:  "v1.30/stable",
+			},
+		},
+		{
+			name: "RevisionOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionRevision,
+				Value:  "123",
+			},
+		},
+		{
+			name: "LocalPathOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionLocalPath,
+				Value:  "/path/to/k8s.snap",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			config, err := cloudinit.NewJoinControlPlane(cloudinit.JoinControlPlaneInput{
+				BaseUserData: cloudinit.BaseUserData{
+					KubernetesVersion: "v1.30.0",
+					SnapInstallData:   tt.snapInstall,
+					BootCommands:      []string{"bootcmd"},
+					PreRunCommands:    []string{"prerun1", "prerun2"},
+					PostRunCommands:   []string{"postrun1", "postrun2"},
+				}})
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(config.WriteFiles).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Path":    Equal(fmt.Sprintf("/capi/etc/snap-%s", tt.snapInstall.Option)),
+				"Content": Equal(tt.snapInstall.Value),
+			})))
+		})
+	}
 }

--- a/pkg/cloudinit/scripts/install.sh
+++ b/pkg/cloudinit/scripts/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -xe
 
 ## Assumptions:
-## - /capi/etc/snap-track contains the snap track that matches the installed Kubernetes version, e.g. "v1.30.1" -> "1.30-classic/stable"
+## - /capi/etc/snap-channel contains the snap channel to be installed that matches the desired Kubernetes version, e.g. "v1.30.1" -> "1.30-classic/stable"
 ## - /capi/etc/snap-revision contains the snap revision to be installed, e.g. 123
 ## - /capi/etc/snap-local-path contains the path to the local snap file to be installed, e.g. /path/to/k8s.snap
 
-if [ -f "/capi/etc/snap-track" ]; then
-  snap_track="$(cat /capi/etc/snap-track)"
-  snap install k8s --classic --channel "${snap_track}"
+if [ -f "/capi/etc/snap-channel" ]; then
+  snap_channel="$(cat /capi/etc/snap-channel)"
+  snap install k8s --classic --channel "${snap_channel}"
 elif [ -f "/capi/etc/snap-revision" ]; then
   snap_revision="$(cat /capi/etc/snap-revision)"
   snap install k8s --classic --revision "${snap_revision}"

--- a/pkg/cloudinit/scripts/install.sh
+++ b/pkg/cloudinit/scripts/install.sh
@@ -2,7 +2,19 @@
 
 ## Assumptions:
 ## - /capi/etc/snap-track contains the snap track that matches the installed Kubernetes version, e.g. "v1.30.1" -> "1.30-classic/stable"
+## - /capi/etc/snap-revision contains the snap revision to be installed, e.g. 123
+## - /capi/etc/snap-local-path contains the path to the local snap file to be installed, e.g. /path/to/k8s.snap
 
-snap_track="$(cat /capi/etc/snap-track)"
-
-snap install k8s --classic --channel "${snap_track}"
+if [ -f "/capi/etc/snap-track" ]; then
+  snap_track="$(cat /capi/etc/snap-track)"
+  snap install k8s --classic --channel "${snap_track}"
+elif [ -f "/capi/etc/snap-revision" ]; then
+  snap_revision="$(cat /capi/etc/snap-revision)"
+  snap install k8s --classic --revision "${snap_revision}"
+elif [ -f "/capi/etc/snap-local-path" ]; then
+  snap_local_path="$(cat /capi/etc/snap-local-path)"
+  snap install k8s --classic --dangerous "${snap_local_path}"
+else
+  echo "No snap installation option found"
+  exit 1
+fi

--- a/pkg/cloudinit/worker_join_test.go
+++ b/pkg/cloudinit/worker_join_test.go
@@ -67,7 +67,7 @@ func TestNewJoinWorker(t *testing.T) {
 		HaveField("Path", "/capi/etc/node-name"),
 		HaveField("Path", "/capi/etc/node-token"),
 		HaveField("Path", "/capi/etc/join-token"),
-		HaveField("Path", "/capi/etc/snap-track"),
+		HaveField("Path", "/capi/etc/snap-channel"),
 		HaveField("Path", "/tmp/file"),
 	), "Some /capi/scripts files are missing")
 }

--- a/pkg/cloudinit/worker_join_test.go
+++ b/pkg/cloudinit/worker_join_test.go
@@ -1,9 +1,11 @@
 package cloudinit_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 
 	"github.com/canonical/cluster-api-k8s/pkg/cloudinit"
 )
@@ -104,4 +106,75 @@ func TestNewJoinWorkerAirGapped(t *testing.T) {
 
 	// Verify the run commands is missing install.sh script.
 	g.Expect(config.RunCommands).NotTo(ContainElement("/capi/scripts/install.sh"))
+}
+
+func TestNewJoinWorkerSnapInstall(t *testing.T) {
+	t.Run("DefaultSnapInstall", func(t *testing.T) {
+		g := NewWithT(t)
+
+		config, err := cloudinit.NewJoinWorker(cloudinit.JoinWorkerInput{
+			BaseUserData: cloudinit.BaseUserData{
+				KubernetesVersion: "v1.30.0",
+				BootCommands:      []string{"bootcmd"},
+				PreRunCommands:    []string{"prerun1", "prerun2"},
+				PostRunCommands:   []string{"postrun1", "postrun2"},
+			}})
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(config.WriteFiles).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+			"Path":    Equal(fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionChannel)),
+			"Content": Equal("1.30-classic/stable"),
+		})))
+		g.Expect(config.WriteFiles).ToNot(ContainElement(HaveField("Path", fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionRevision))))
+		g.Expect(config.WriteFiles).ToNot(ContainElement(HaveField("Path", fmt.Sprintf("/capi/etc/snap-%s", cloudinit.InstallOptionLocalPath))))
+	})
+
+	tests := []struct {
+		name        string
+		snapInstall cloudinit.SnapInstallData
+	}{
+		{
+			name: "ChannelOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionChannel,
+				Value:  "v1.30/stable",
+			},
+		},
+		{
+			name: "RevisionOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionRevision,
+				Value:  "123",
+			},
+		},
+		{
+			name: "LocalPathOverride",
+			snapInstall: cloudinit.SnapInstallData{
+				Option: cloudinit.InstallOptionLocalPath,
+				Value:  "/path/to/k8s.snap",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			config, err := cloudinit.NewJoinWorker(cloudinit.JoinWorkerInput{
+				BaseUserData: cloudinit.BaseUserData{
+					KubernetesVersion: "v1.30.0",
+					SnapInstallData:   tt.snapInstall,
+					BootCommands:      []string{"bootcmd"},
+					PreRunCommands:    []string{"prerun1", "prerun2"},
+					PostRunCommands:   []string{"postrun1", "postrun2"},
+				}})
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(config.WriteFiles).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Path":    Equal(fmt.Sprintf("/capi/etc/snap-%s", tt.snapInstall.Option)),
+				"Content": Equal(tt.snapInstall.Value),
+			})))
+		})
+	}
 }


### PR DESCRIPTION
This PR adjusts the ck8s config reconciler to use the snap install option from an in-place upgrade release annotation if it exists. This can be utilized by adding the release annotation under the `CK8sControlPlane` or `MachineDeployment` specs, which will be propagated down to the machine.

For control-plane (CK8sControlPlane)
`.spec.machineTemplate.metadata.annotations => Machine.annotations`

Adopted something similar to [propagation logic from KCP](https://github.com/kubernetes-sigs/cluster-api/blob/377b79c272a660064b97745bad85a6f77bc7a2d2/controlplane/kubeadm/internal/controllers/controller.go#L644-L751)

For workers (MachineDeployment)
`.spec.template.metadata.annotations => MachineSet.spec.template.metadata.annotations  => Machine.annotations`