### PR TITLE
Disable default k8s services for AMI

### DIFF
--- a/templates/aws/cluster-template.yaml
+++ b/templates/aws/cluster-template.yaml
@@ -58,6 +58,11 @@ spec:
         owner: "root:root"
         content: |
           #!/bin/bash -xe
+          # TODO(ben): This is a temporary workaround until we build our own AMI without default Kubernetes components.
+          systemctl stop kubelet
+          systemctl disable kubelet
+          systemctl stop containerd
+          systemctl disable containerd
           snap install k8s --classic --edge
     controlPlane:
       cloudProvider: external

--- a/templates/aws/template-variables.rc
+++ b/templates/aws/template-variables.rc
@@ -1,19 +1,19 @@
 # Kubernetes cluster configuration
-export KUBERNETES_VERSION=v1.30.0
-export CONTROL_PLANE_MACHINE_COUNT=                 # e.g. 1
-export WORKER_MACHINE_COUNT=
+export KUBERNETES_VERSION=v1.31.0
+export CONTROL_PLANE_MACHINE_COUNT=1
+export WORKER_MACHINE_COUNT=1
 
 # AWS region
-export AWS_REGION=""                                # e.g. "us-east-2"
+export AWS_REGION="eu-central-1"
 
 # AWS machine configuration
-export AWS_CREATE_BASTION=                          # e.g. "true"
-export AWS_PUBLIC_IP=                               # e.g. "true"
-export AWS_CONTROL_PLANE_INSTANCE_TYPE=             # e.g. "t3.large"
-export AWS_NODE_INSTANCE_TYPE=                      # e.g. "t3.large"
-export AWS_CONTROL_PLANE_ROOT_VOLUME_SIZE=          # in Gigabyte, e.g. 16
-export AWS_NODE_ROOT_VOLUME_SIZE=                   # in Gigabyte, e.g. 16
-export AWS_SSH_KEY_NAME=                            # e.g. "default"
-export AWS_AMI_ID=                                  # e.g. "ami-0ad50e72a79228704"
+export AWS_CREATE_BASTION="true"
+export AWS_PUBLIC_IP="true"
+export AWS_CONTROL_PLANE_INSTANCE_TYPE="t3.large"
+export AWS_NODE_INSTANCE_TYPE="t3.large"
+export AWS_CONTROL_PLANE_ROOT_VOLUME_SIZE=16
+export AWS_NODE_ROOT_VOLUME_SIZE=16
+export AWS_SSH_KEY_NAME="default"
+export AWS_AMI_ID="ami-027b534ab5d0b4886"
 
 export AWS_CCM_IMAGE=registry.k8s.io/provider-aws/cloud-controller-manager:v1.28.3


### PR DESCRIPTION
# Summary
Disable k8s services on new default AMI.

# Rationale
The CAPA provider was broken because of a cloud-init issue. See https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5115. Upstream implemented a temporary workaround to pin the cloud-init version https://github.com/kubernetes-sigs/image-builder/pull/1590. 
We can now use the new AMI from upstream. This image contains kubelet and containerd by default so we need to disable them before bootstrapping the `k8s-snap`.

A permanent solution is worked out here: https://github.com/kubernetes-sigs/image-builder/pull/1583. Once this is done, we need to start build our own AMIs as part of our release workflow to provide supported AMIs for each release. We already have a card to work on this. 

I also slightly changed the template variables to have defaults instead of just suggestions. IMHO it is weird to need to copy all those values. Now, only the values one wants to change need to be touched.