### PR TITLE
Add CP orchestrated in-place upgrade controller

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,6 +65,7 @@ jobs:
           - "Workload cluster creation"
           - "Workload cluster scaling"
           - "Workload cluster upgrade"
+          - "Orchestrated In place upgrades"
       # TODO(ben): Remove once all tests are running stable.
       fail-fast: false
     steps:

--- a/controlplane/config/rbac/role.yaml
+++ b/controlplane/config/rbac/role.yaml
@@ -49,6 +49,23 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
   - ""
   resources:
   - events

--- a/controlplane/config/rbac/role.yaml
+++ b/controlplane/config/rbac/role.yaml
@@ -65,6 +65,8 @@ rules:
   - create
   - delete
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controlplane/controllers/orchestrated_inplace_upgrade_controller.go
+++ b/controlplane/controllers/orchestrated_inplace_upgrade_controller.go
@@ -1,0 +1,301 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootstrapv1 "github.com/canonical/cluster-api-k8s/bootstrap/api/v1beta2"
+	controlplanev1 "github.com/canonical/cluster-api-k8s/controlplane/api/v1beta2"
+	"github.com/canonical/cluster-api-k8s/pkg/ck8s"
+	"github.com/canonical/cluster-api-k8s/pkg/trace"
+	"github.com/canonical/cluster-api-k8s/pkg/upgrade/inplace"
+)
+
+// OrchestratedInPlaceUpgradeController reconciles a CK8sControlPlane object and manages the in-place upgrades.
+type OrchestratedInPlaceUpgradeController struct {
+	scheme        *runtime.Scheme
+	recorder      record.EventRecorder
+	machineGetter inplace.MachineGetter
+
+	client.Client
+	Log  logr.Logger
+	lock inplace.UpgradeLock
+}
+
+// OrchestratedInPlaceUpgradeScope is a struct that holds the context of the upgrade process.
+type OrchestratedInPlaceUpgradeScope struct {
+	cluster          *clusterv1.Cluster
+	ck8sControlPlane *controlplanev1.CK8sControlPlane
+	ck8sPatcher      inplace.Patcher
+	upgradeTo        string
+	ownedMachines    collections.Machines
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *OrchestratedInPlaceUpgradeController) SetupWithManager(mgr ctrl.Manager) error {
+	r.scheme = mgr.GetScheme()
+	r.recorder = mgr.GetEventRecorderFor("ck8s-cp-orchestrated-inplace-upgrade-controller")
+	r.machineGetter = &ck8s.Management{
+		Client: r.Client,
+	}
+	r.lock = inplace.NewUpgradeLock(r.Client)
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&controlplanev1.CK8sControlPlane{}).
+		Owns(&clusterv1.Machine{}).
+		Complete(r); err != nil {
+		return fmt.Errorf("failed to get new controller builder: %w", err)
+	}
+
+	return nil
+}
+
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;create;delete
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets;machinesets/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+// Reconcile handles the reconciliation of a CK8sControlPlane object.
+func (r *OrchestratedInPlaceUpgradeController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	traceID := trace.NewID()
+	log := r.Log.WithValues("orchestrated_inplace_upgrade", req.NamespacedName, "trace_id", traceID)
+	log.V(1).Info("Reconciliation started...")
+
+	ck8sCP := &controlplanev1.CK8sControlPlane{}
+	if err := r.Get(ctx, req.NamespacedName, ck8sCP); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("CK8sControlPlane resource not found. Ignoring since the object must be deleted.")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get CK8sControlPlane: %w", err)
+	}
+
+	if inplace.GetUpgradeInstructions(ck8sCP) == "" {
+		log.V(1).Info("CK8sControlPlane has no upgrade instructions, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	if isDeleted(ck8sCP) {
+		log.V(1).Info("CK8sControlPlane is being deleted, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	if !r.machinesAreReady(ck8sCP) {
+		log.V(1).Info("Machines are not ready, requeuing...")
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	scope, err := r.createScope(ctx, ck8sCP)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create scope: %w", err)
+	}
+
+	upgradingMachine, err := r.lock.IsLocked(ctx, scope.cluster)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check if upgrade is locked: %w", err)
+	}
+
+	// Upgrade is locked and a machine is already upgrading
+	if upgradingMachine != nil {
+		// NOTE(Hue): Maybe none of the `upgrade-to` and `release` annotations are set on the machine.
+		// If that's the case, the machine will never get upgraded.
+		// We consider this a stale lock and unlock the upgrade process.
+		if inplace.GetUpgradeInstructions(upgradingMachine) != scope.upgradeTo {
+			log.V(1).Info("Machine does not have expected upgrade instructions, unlocking...", "machine", upgradingMachine.Name)
+			if err := r.lock.Unlock(ctx, scope.cluster); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to unlock upgrade: %w", err)
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if inplace.IsUpgraded(upgradingMachine, scope.upgradeTo) {
+			if err := r.lock.Unlock(ctx, scope.cluster); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to unlock upgrade: %w", err)
+			}
+
+			return ctrl.Result{Requeue: true}, nil
+		}
+
+		if inplace.IsMachineUpgradeFailed(upgradingMachine) {
+			log.Info("Machine upgrade failed for machine, requeuing...", "machine", upgradingMachine.Name)
+			if err := r.markUpgradeFailed(ctx, scope, upgradingMachine); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to mark upgrade as failed: %w", err)
+			}
+
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		log.V(1).Info("Upgrade is locked, a machine is upgrading, requeuing...", "machine", upgradingMachine.Name)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	// Check if there are machines to upgrade
+	var upgradedMachines int
+	for _, m := range scope.ownedMachines {
+		if inplace.IsUpgraded(m, scope.upgradeTo) {
+			log.V(1).Info("Machine is already upgraded", "machine", m.Name)
+			upgradedMachines++
+			continue
+		}
+
+		if isDeleted(m) {
+			log.V(1).Info("Machine is being deleted, requeuing...", "machine", m.Name)
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		// Lock the process for the machine and start the upgrade
+		if err := r.lock.Lock(ctx, scope.cluster, m); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to lock upgrade for machine %q: %w", m.Name, err)
+		}
+
+		if err := r.markMachineToUpgrade(ctx, scope, m); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to mark machine to upgrade: %w", err)
+		}
+
+		log.V(1).Info("Machine marked for upgrade", "machine", m.Name)
+
+		if err := r.markUpgradeInProgress(ctx, scope, m); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to mark upgrade as in-progress: %w", err)
+		}
+
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	if upgradedMachines == len(scope.ownedMachines) {
+		if err := r.markUpgradeDone(ctx, scope); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to mark upgrade as done: %w", err)
+		}
+
+		log.V(1).Info("All machines are upgraded")
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+}
+
+// markUpgradeInProgress annotates the CK8sControlPlane with in-place upgrade in-progress.
+func (r *OrchestratedInPlaceUpgradeController) markUpgradeInProgress(ctx context.Context, scope *OrchestratedInPlaceUpgradeScope, upgradingMachine *clusterv1.Machine) error {
+	if err := inplace.MarkUpgradeInProgress(ctx, scope.ck8sControlPlane, scope.upgradeTo, scope.ck8sPatcher); err != nil {
+		return fmt.Errorf("failed to mark object with upgrade in-progress: %w", err)
+	}
+
+	r.recorder.Eventf(
+		scope.ck8sControlPlane,
+		corev1.EventTypeNormal,
+		bootstrapv1.InPlaceUpgradeInProgressEvent,
+		"In-place upgrade is in-progress for %q",
+		upgradingMachine.Name,
+	)
+	return nil
+}
+
+// markUpgradeDone annotates the CK8sControlPlane with in-place upgrade done.
+func (r *OrchestratedInPlaceUpgradeController) markUpgradeDone(ctx context.Context, scope *OrchestratedInPlaceUpgradeScope) error {
+	if err := inplace.MarkUpgradeDone(ctx, scope.ck8sControlPlane, scope.upgradeTo, scope.ck8sPatcher); err != nil {
+		return fmt.Errorf("failed to mark object with upgrade done: %w", err)
+	}
+
+	r.recorder.Eventf(
+		scope.ck8sControlPlane,
+		corev1.EventTypeNormal,
+		bootstrapv1.InPlaceUpgradeDoneEvent,
+		"In-place upgrade is done",
+	)
+	return nil
+}
+
+// markUpgradeFailed annotates the CK8sControlPlane with in-place upgrade failed.
+func (r *OrchestratedInPlaceUpgradeController) markUpgradeFailed(ctx context.Context, scope *OrchestratedInPlaceUpgradeScope, failedM *clusterv1.Machine) error {
+	if err := inplace.MarkUpgradeFailed(ctx, scope.ck8sControlPlane, scope.ck8sPatcher); err != nil {
+		return fmt.Errorf("failed to mark object with upgrade failed: %w", err)
+	}
+
+	r.recorder.Eventf(
+		scope.ck8sControlPlane,
+		corev1.EventTypeWarning,
+		bootstrapv1.InPlaceUpgradeFailedEvent,
+		"In-place upgrade failed for machine %q.",
+		failedM.Name,
+	)
+	return nil
+}
+
+// createScope creates a new OrchestratedInPlaceUpgradeScope.
+func (r *OrchestratedInPlaceUpgradeController) createScope(ctx context.Context, ck8sCP *controlplanev1.CK8sControlPlane) (*OrchestratedInPlaceUpgradeScope, error) {
+	patchHelper, err := patch.NewHelper(ck8sCP, r.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new patch helper: %w", err)
+	}
+
+	cluster, err := util.GetOwnerCluster(ctx, r.Client, ck8sCP.ObjectMeta)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster: %w", err)
+	}
+
+	ownedMachines, err := r.getControlPlaneMachines(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get owned machines: %w", err)
+	}
+
+	return &OrchestratedInPlaceUpgradeScope{
+		cluster:          cluster,
+		ck8sControlPlane: ck8sCP,
+		upgradeTo:        inplace.GetUpgradeInstructions(ck8sCP),
+		ownedMachines:    ownedMachines,
+		ck8sPatcher:      patchHelper,
+	}, nil
+}
+
+// getControlPlaneMachines gets the control plane machines of the cluster.
+func (r *OrchestratedInPlaceUpgradeController) getControlPlaneMachines(ctx context.Context, cluster *clusterv1.Cluster) (collections.Machines, error) {
+	ownedMachines, err := r.machineGetter.GetMachinesForCluster(ctx, client.ObjectKeyFromObject(cluster), collections.ControlPlaneMachines(cluster.Name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster machines: %w", err)
+	}
+
+	return ownedMachines, nil
+}
+
+// markMachineToUpgrade marks the machine to upgrade.
+func (r *OrchestratedInPlaceUpgradeController) markMachineToUpgrade(ctx context.Context, scope *OrchestratedInPlaceUpgradeScope, m *clusterv1.Machine) error {
+	if err := inplace.MarkMachineToUpgrade(ctx, m, scope.upgradeTo, r.Client); err != nil {
+		return fmt.Errorf("failed to mark machine to inplace upgrade: %w", err)
+	}
+
+	r.recorder.Eventf(
+		scope.ck8sControlPlane,
+		corev1.EventTypeNormal,
+		bootstrapv1.InPlaceUpgradeInProgressEvent,
+		"Machine %q is upgrading to %q",
+		m.Name,
+		scope.upgradeTo,
+	)
+
+	return nil
+}
+
+func (r *OrchestratedInPlaceUpgradeController) machinesAreReady(ck8sCP *controlplanev1.CK8sControlPlane) bool {
+	if ck8sCP == nil || ck8sCP.Spec.Replicas == nil {
+		return false
+	}
+	return ck8sCP.Status.ReadyReplicas == *ck8sCP.Spec.Replicas
+}
+
+// isDeleted returns true if the object is being deleted.
+func isDeleted(obj client.Object) bool {
+	return !obj.GetDeletionTimestamp().IsZero()
+}

--- a/controlplane/controllers/orchestrated_inplace_upgrade_controller.go
+++ b/controlplane/controllers/orchestrated_inplace_upgrade_controller.go
@@ -63,7 +63,7 @@ func (r *OrchestratedInPlaceUpgradeController) SetupWithManager(mgr ctrl.Manager
 	return nil
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;create;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;create;delete;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets;machinesets/status,verbs=get;list;watch

--- a/controlplane/main.go
+++ b/controlplane/main.go
@@ -116,6 +116,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	inplaceUpgradeLogger := ctrl.Log.WithName("controllers").WithName("OrchestratedInPlaceUpgrade")
+	if err = (&controllers.OrchestratedInPlaceUpgradeController{
+		Client: mgr.GetClient(),
+		Log:    inplaceUpgradeLogger,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "failed to create controller", "controller", "OrchestratedInPlaceUpgrade")
+	}
+
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		if err = (&controlplanev1.CK8sControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "CK8sControlPlane")

--- a/pkg/upgrade/inplace/inplace.go
+++ b/pkg/upgrade/inplace/inplace.go
@@ -1,0 +1,44 @@
+package inplace
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootstrapv1 "github.com/canonical/cluster-api-k8s/bootstrap/api/v1beta2"
+)
+
+// IsUpgraded checks if the object is already upgraded to the specified release.
+func IsUpgraded(obj client.Object, release string) bool {
+	return obj.GetAnnotations()[bootstrapv1.InPlaceUpgradeReleaseAnnotation] == release
+}
+
+// GetUpgradeInstructions returns the in-place upgrade instructions set on the object.
+func GetUpgradeInstructions(obj client.Object) string {
+	// NOTE(Hue): The reason we are checking the `release` annotation as well is that we want to make sure
+	// we upgrade the new machines that joined after the initial upgrade process.
+	// The `upgrade-to` overwrites the `release` annotation, because we might have both in case
+	// the user decides to do another in-place upgrade after a successful one.
+	upgradeTo := obj.GetAnnotations()[bootstrapv1.InPlaceUpgradeReleaseAnnotation]
+	if to, ok := obj.GetAnnotations()[bootstrapv1.InPlaceUpgradeToAnnotation]; ok {
+		upgradeTo = to
+	}
+
+	return upgradeTo
+}
+
+// IsMachineUpgradeFailed checks if the machine upgrade failed.
+// The upgrade might be getting retried at the moment of the check. This check insures that the upgrade failed *at some point*.
+func IsMachineUpgradeFailed(m *clusterv1.Machine) bool {
+	return m.Annotations[bootstrapv1.InPlaceUpgradeLastFailedAttemptAtAnnotation] != ""
+}
+
+// IsMachineUpgrading checks if the object is upgrading.
+func IsMachineUpgrading(m *clusterv1.Machine) bool {
+	// NOTE(Hue): We can't easily generalize this function to check for all objects.
+	// Generally speaking, the `status == in-progress` should indicate that the object is upgrading.
+	// But from the orchestrated upgrade perspective, we need to also check the `upgrade-to` annotation
+	// so that we know if the single machine inplace upgrade
+	// controller is going to handle the upgrade process, hence "in-progress".
+	return m.Annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation] == bootstrapv1.InPlaceUpgradeInProgressStatus ||
+		m.Annotations[bootstrapv1.InPlaceUpgradeToAnnotation] != ""
+}

--- a/pkg/upgrade/inplace/interface.go
+++ b/pkg/upgrade/inplace/interface.go
@@ -1,0 +1,19 @@
+package inplace
+
+import (
+	"context"
+
+	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MachineGetter is an interface that defines the methods used to get machines.
+type MachineGetter interface {
+	GetMachinesForCluster(ctx context.Context, cluster client.ObjectKey, filters ...collections.Func) (collections.Machines, error)
+}
+
+// Patcher is an interface that knows how to patch an object.
+type Patcher interface {
+	Patch(ctx context.Context, obj client.Object, opts ...patch.Option) error
+}

--- a/pkg/upgrade/inplace/lock.go
+++ b/pkg/upgrade/inplace/lock.go
@@ -1,0 +1,192 @@
+package inplace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UpgradeLock is an interface that defines the methods used to lock and unlock the inplace upgrade process.
+type UpgradeLock interface {
+	// IsLocked checks if the upgrade process is locked and (if locked) returns the machine that the process is locked for.
+	IsLocked(ctx context.Context, cluster *clusterv1.Cluster) (*clusterv1.Machine, error)
+	// Lock is a non-blocking call that tries to lock the upgrade process for the given machine.
+	Lock(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine) error
+	// Unlock unlocks the upgrade process.
+	Unlock(ctx context.Context, cluster *clusterv1.Cluster) error
+}
+
+const (
+	lockConfigMapNameSuffix = "cp-inplace-upgrade-lock"
+	lockInformationKey      = "lock-information"
+)
+
+func NewUpgradeLock(c client.Client) *upgradeLock {
+	return &upgradeLock{
+		c:         c,
+		semaphore: &semaphore{},
+	}
+}
+
+type upgradeLock struct {
+	c         client.Client
+	semaphore *semaphore
+}
+
+type semaphore struct {
+	configMap *corev1.ConfigMap
+}
+
+func newSemaphore() *semaphore {
+	return &semaphore{configMap: &corev1.ConfigMap{}}
+}
+
+func (s *semaphore) getLockInfo() (*lockInformation, error) {
+	if s.configMap == nil {
+		return nil, errors.New("configmap is nil")
+	}
+	if s.configMap.Data == nil {
+		return nil, errors.New("configmap data is nil")
+	}
+	liStr, ok := s.configMap.Data[lockInformationKey]
+	if !ok {
+		return nil, errors.New("lock information key not found")
+	}
+
+	li := &lockInformation{}
+	if err := json.Unmarshal([]byte(liStr), li); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal lock information: %w", err)
+	}
+
+	return li, nil
+}
+
+func (s *semaphore) setLockInfo(li lockInformation) error {
+	if s.configMap == nil {
+		s.configMap = &corev1.ConfigMap{}
+	}
+	if s.configMap.Data == nil {
+		s.configMap.Data = make(map[string]string)
+	}
+
+	liStr, err := json.Marshal(li)
+	if err != nil {
+		return fmt.Errorf("failed to marshal lock information: %w", err)
+	}
+
+	s.configMap.Data[lockInformationKey] = string(liStr)
+	return nil
+}
+
+func (s *semaphore) setMetadata(cluster *clusterv1.Cluster) {
+	if s.configMap == nil {
+		s.configMap = &corev1.ConfigMap{}
+	}
+
+	s.configMap.ObjectMeta = metav1.ObjectMeta{
+		Namespace: cluster.Namespace,
+		Name:      configMapName(cluster.Name),
+		Labels: map[string]string{
+			clusterv1.ClusterNameLabel: cluster.Name,
+		},
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       clusterv1.ClusterKind,
+				Name:       cluster.Name,
+				UID:        cluster.UID,
+			},
+		},
+	}
+}
+
+type lockInformation struct {
+	MachineName      string `json:"machineName"`
+	MachineNamespace string `json:"machineNamespace"`
+}
+
+func configMapName(clusterName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, lockConfigMapNameSuffix)
+}
+
+// IsLocked checks if the upgrade process is locked and (if locked) returns the machine that the process is locked for.
+func (l *upgradeLock) IsLocked(ctx context.Context, cluster *clusterv1.Cluster) (*clusterv1.Machine, error) {
+	l.semaphore = newSemaphore()
+	name := configMapName(cluster.Name)
+	if err := l.c.Get(ctx, client.ObjectKey{Name: name, Namespace: cluster.Namespace}, l.semaphore.configMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get configmap %q: %w", name, err)
+	}
+
+	li, err := l.semaphore.getLockInfo()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get lock information: %w", err)
+	}
+
+	machine := &clusterv1.Machine{}
+	if err := l.c.Get(ctx, client.ObjectKey{Name: li.MachineName, Namespace: li.MachineNamespace}, machine); err != nil {
+		// must be a stale lock from a deleted machine, unlock.
+		if apierrors.IsNotFound(err) {
+			if err := l.Unlock(ctx, cluster); err != nil {
+				return nil, fmt.Errorf("failed to unlock: %w", err)
+			}
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get machine %q: %w", li.MachineName, err)
+	}
+
+	return machine, nil
+}
+
+// Unlock unlocks the upgrade process.
+func (l *upgradeLock) Unlock(ctx context.Context, cluster *clusterv1.Cluster) error {
+	cm := &corev1.ConfigMap{}
+	name := configMapName(cluster.Name)
+	if err := l.c.Get(ctx, client.ObjectKey{Name: name, Namespace: cluster.Namespace}, cm); err != nil {
+		// if the configmap is not found, it means the lock is already released.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get configmap %q: %w", name, err)
+	}
+
+	if err := l.c.Delete(ctx, cm); err != nil {
+		// if the configmap is not found, it means the lock is already released.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete configmap %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// Lock locks the upgrade process for the given machine.
+func (l *upgradeLock) Lock(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+	l.semaphore = newSemaphore()
+	li := lockInformation{
+		MachineName:      machine.Name,
+		MachineNamespace: machine.Namespace,
+	}
+	if err := l.semaphore.setLockInfo(li); err != nil {
+		return fmt.Errorf("failed to set lock information: %w", err)
+	}
+	l.semaphore.setMetadata(cluster)
+
+	if err := l.c.Create(ctx, l.semaphore.configMap); err != nil {
+		return fmt.Errorf("failed to create configmap: %w", err)
+	}
+
+	return nil
+}
+
+var _ UpgradeLock = &upgradeLock{}

--- a/pkg/upgrade/inplace/mark.go
+++ b/pkg/upgrade/inplace/mark.go
@@ -1,0 +1,102 @@
+package inplace
+
+import (
+	"context"
+	"fmt"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootstrapv1 "github.com/canonical/cluster-api-k8s/bootstrap/api/v1beta2"
+)
+
+// MarkMachineToUpgrade marks the machine to upgrade.
+func MarkMachineToUpgrade(ctx context.Context, m *clusterv1.Machine, to string, c client.Client) error {
+	patchHelper, err := patch.NewHelper(m, c)
+	if err != nil {
+		return fmt.Errorf("failed to create new patch helper: %w", err)
+	}
+
+	if m.Annotations == nil {
+		m.Annotations = make(map[string]string)
+	}
+
+	// clean up
+	delete(m.Annotations, bootstrapv1.InPlaceUpgradeReleaseAnnotation)
+	delete(m.Annotations, bootstrapv1.InPlaceUpgradeStatusAnnotation)
+	delete(m.Annotations, bootstrapv1.InPlaceUpgradeChangeIDAnnotation)
+	delete(m.Annotations, bootstrapv1.InPlaceUpgradeLastFailedAttemptAtAnnotation)
+
+	m.Annotations[bootstrapv1.InPlaceUpgradeToAnnotation] = to
+
+	if err := patchHelper.Patch(ctx, m); err != nil {
+		return fmt.Errorf("failed to patch: %w", err)
+	}
+
+	return nil
+}
+
+// MarkUpgradeFailed annotates the object with in-place upgrade failed.
+func MarkUpgradeFailed(ctx context.Context, obj client.Object, patcher Patcher) error {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// clean up
+	delete(annotations, bootstrapv1.InPlaceUpgradeReleaseAnnotation)
+
+	annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation] = bootstrapv1.InPlaceUpgradeFailedStatus
+	obj.SetAnnotations(annotations)
+
+	if err := patcher.Patch(ctx, obj); err != nil {
+		return fmt.Errorf("failed to patch: %w", err)
+	}
+
+	return nil
+}
+
+// MarkUpgradeInProgress annotates the object with in-place upgrade in-progress.
+func MarkUpgradeInProgress(ctx context.Context, obj client.Object, to string, patcher Patcher) error {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// clean up
+	delete(annotations, bootstrapv1.InPlaceUpgradeReleaseAnnotation)
+
+	annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation] = bootstrapv1.InPlaceUpgradeInProgressStatus
+	annotations[bootstrapv1.InPlaceUpgradeToAnnotation] = to
+
+	obj.SetAnnotations(annotations)
+
+	if err := patcher.Patch(ctx, obj); err != nil {
+		return fmt.Errorf("failed to patch: %w", err)
+	}
+
+	return nil
+}
+
+// MarkUpgradeDone annotates the object with in-place upgrade done.
+func MarkUpgradeDone(ctx context.Context, obj client.Object, to string, patcher Patcher) error {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// clean up
+	delete(annotations, bootstrapv1.InPlaceUpgradeToAnnotation)
+
+	annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation] = bootstrapv1.InPlaceUpgradeDoneStatus
+	annotations[bootstrapv1.InPlaceUpgradeReleaseAnnotation] = to
+
+	obj.SetAnnotations(annotations)
+
+	if err := patcher.Patch(ctx, obj); err != nil {
+		return fmt.Errorf("failed to patch: %w", err)
+	}
+
+	return nil
+}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -594,7 +594,7 @@ func ApplyInPlaceUpgradeAndWait(ctx context.Context, input ApplyInPlaceUpgradeAn
 
 	Eventually(func() (bool, error) {
 		if err := input.Getter.Get(ctx, client.ObjectKeyFromObject(input.Obj), input.DestinationObj); err != nil {
-			Byf("Failed to get the machine: %+v", err)
+			Byf("Failed to get the object: %+v", err)
 			return false, err
 		}
 
@@ -728,19 +728,106 @@ func ApplyInPlaceUpgradeForMachineDeployment(ctx context.Context, input ApplyInP
 
 	// Make sure all the machines are upgraded
 	inClustersNamespaceListOption := client.InNamespace(input.Cluster.Namespace)
-	matchClusterListOption := client.MatchingLabels{
+	belongsToMDListOption := client.MatchingLabels{
 		clusterv1.ClusterNameLabel:           input.Cluster.Name,
 		clusterv1.MachineDeploymentNameLabel: machineDeployment.Name,
 	}
 
-	machineList := &clusterv1.MachineList{}
+	mdMachineList := &clusterv1.MachineList{}
 	Eventually(func() error {
-		return input.Lister.List(ctx, machineList, inClustersNamespaceListOption, matchClusterListOption)
+		return input.Lister.List(ctx, mdMachineList, inClustersNamespaceListOption, belongsToMDListOption)
 	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Couldn't list machines for the machineDeployment %q", machineDeployment.Name)
 
-	for _, machine := range machineList.Items {
+	for _, machine := range mdMachineList.Items {
 		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation]).To(Equal(bootstrapv1.InPlaceUpgradeDoneStatus))
 		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeReleaseAnnotation]).To(Equal(input.UpgradeOption))
+	}
+
+	// Make sure other machines are not upgraded
+	allMachines := &clusterv1.MachineList{}
+	Eventually(func() error {
+		return input.Lister.List(ctx, allMachines, inClustersNamespaceListOption)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Couldn't list all machines")
+
+	for _, machine := range allMachines.Items {
+		// skip the ones belong to the MD under test machines
+		if isMachineInList(machine, mdMachineList) {
+			continue
+		}
+
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeToAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeLastFailedAttemptAtAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeChangeIDAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeReleaseAnnotation]).To(BeEmpty())
+	}
+}
+
+type ApplyInPlaceUpgradeForCK8sControlPlaneInput struct {
+	Lister                  framework.Lister
+	Getter                  framework.Getter
+	ClusterProxy            framework.ClusterProxy
+	Cluster                 *clusterv1.Cluster
+	UpgradeOption           string
+	WaitForUpgradeIntervals []interface{}
+}
+
+func ApplyInPlaceUpgradeForCK8sControlPlane(ctx context.Context, input ApplyInPlaceUpgradeForCK8sControlPlaneInput) {
+	Expect(ctx).NotTo(BeNil())
+	Expect(input.ClusterProxy).ToNot(BeNil())
+	Expect(input.Cluster).ToNot(BeNil())
+	Expect(input.UpgradeOption).ToNot(BeEmpty())
+
+	ck8sCP := GetCK8sControlPlaneByCluster(ctx, GetCK8sControlPlaneByClusterInput{
+		Lister:      input.Lister,
+		ClusterName: input.Cluster.Name,
+		Namespace:   input.Cluster.Namespace,
+	})
+	Expect(ck8sCP).ToNot(BeNil())
+
+	ApplyInPlaceUpgradeAndWait(ctx, ApplyInPlaceUpgradeAndWaitInput{
+		Getter:                  input.Getter,
+		Obj:                     ck8sCP,
+		DestinationObj:          &controlplanev1.CK8sControlPlane{},
+		ClusterProxy:            input.ClusterProxy,
+		UpgradeOption:           input.UpgradeOption,
+		WaitForUpgradeIntervals: input.WaitForUpgradeIntervals,
+	})
+
+	// Make sure all the machines are upgraded
+	inClustersNamespaceListOption := client.InNamespace(input.Cluster.Namespace)
+	cpMatchLabelsListOption := client.MatchingLabels{
+		clusterv1.ClusterNameLabel:         input.Cluster.Name,
+		clusterv1.MachineControlPlaneLabel: "",
+	}
+
+	cpMachineList := &clusterv1.MachineList{}
+	Eventually(func() error {
+		return input.Lister.List(ctx, cpMachineList, inClustersNamespaceListOption, cpMatchLabelsListOption)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Couldn't list machines for the CK8sControlPlane %q", ck8sCP.Name)
+
+	for _, machine := range cpMachineList.Items {
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation]).To(Equal(bootstrapv1.InPlaceUpgradeDoneStatus))
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeReleaseAnnotation]).To(Equal(input.UpgradeOption))
+	}
+
+	// Make sure other machines (non-cp ones) are not upgraded
+	allMachines := &clusterv1.MachineList{}
+	Eventually(func() error {
+		return input.Lister.List(ctx, allMachines, inClustersNamespaceListOption)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Couldn't list all machines")
+
+	for _, machine := range allMachines.Items {
+		// skip the control plane machines
+		if isMachineInList(machine, cpMachineList) {
+			continue
+		}
+
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeToAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeLastFailedAttemptAtAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeChangeIDAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeStatusAnnotation]).To(BeEmpty())
+		Expect(machine.Annotations[bootstrapv1.InPlaceUpgradeReleaseAnnotation]).To(BeEmpty())
 	}
 }
 
@@ -876,4 +963,17 @@ func byClusterOptions(name, namespace string) []client.ListOption {
 			clusterv1.ClusterNameLabel: name,
 		},
 	}
+}
+
+func isMachineInList(machine clusterv1.Machine, list *clusterv1.MachineList) bool {
+	if list == nil {
+		return false
+	}
+
+	for _, m := range list.Items {
+		if m.Name == machine.Name {
+			return true
+		}
+	}
+	return false
 }

--- a/test/e2e/orchestrated_cp_in_place_upgrade_test.go
+++ b/test/e2e/orchestrated_cp_in_place_upgrade_test.go
@@ -3,13 +3,10 @@
 
 /*
 Copyright 2021 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,10 +29,10 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
+var _ = Describe("CK8sControlPlane Orchestrated In place upgrades", func() {
 	var (
 		ctx                    = context.TODO()
-		specName               = "workload-cluster-md-inplace"
+		specName               = "workload-cluster-ck8scp-inplace"
 		namespace              *corev1.Namespace
 		cancelWatches          context.CancelFunc
 		result                 *ApplyClusterTemplateAndWaitResult
@@ -47,7 +44,7 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 	BeforeEach(func() {
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
 
-		clusterName = fmt.Sprintf("capick8s-md-in-place-%s", util.RandomString(6))
+		clusterName = fmt.Sprintf("capick8s-ck8scp-in-place-%s", util.RandomString(6))
 		infrastructureProvider = clusterctl.DefaultInfrastructureProvider
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
@@ -73,9 +70,9 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 		dumpSpecResourcesAndCleanup(ctx, cleanInput)
 	})
 
-	Context("Performing Machine Deployment Orchestrated in-place upgrades", func() {
-		It("Creating a workload cluster and applying in-place upgrade to Machine Deployment [MD-InPlace] [PR-Blocking]", func() {
-			By("Creating a workload cluster of 1 control plane and 3 worker nodes")
+	Context("Performing CK8sControlPlane Orchestrated in-place upgrades", func() {
+		It("Creating a workload cluster and applying in-place upgrade to CK8sControlPlane [CK8SCP-InPlace] [PR-Blocking]", func() {
+			By("Creating a workload cluster of 3 control plane and 1 worker nodes")
 			ApplyClusterTemplateAndWait(ctx, ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,
 				ConfigCluster: clusterctl.ConfigClusterInput{
@@ -86,8 +83,8 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 					Namespace:                namespace.Name,
 					ClusterName:              clusterName,
 					KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
-					ControlPlaneMachineCount: ptr.To(int64(1)),
-					WorkerMachineCount:       ptr.To(int64(3)),
+					ControlPlaneMachineCount: ptr.To(int64(3)),
+					WorkerMachineCount:       ptr.To(int64(1)),
 				},
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
@@ -96,15 +93,14 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 
 			bootstrapProxyClient := bootstrapClusterProxy.GetClient()
 
-			By("Applying in place upgrade with local path for MachineDeployment object")
-			ApplyInPlaceUpgradeForMachineDeployment(ctx, ApplyInPlaceUpgradeForMachineDeploymentInput{
+			By("Applying in place upgrade with local path for CK8sControlPlane object")
+			ApplyInPlaceUpgradeForCK8sControlPlane(ctx, ApplyInPlaceUpgradeForCK8sControlPlaneInput{
 				Lister:                  bootstrapProxyClient,
 				Getter:                  bootstrapProxyClient,
 				ClusterProxy:            bootstrapClusterProxy,
 				Cluster:                 result.Cluster,
 				WaitForUpgradeIntervals: e2eConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				UpgradeOption:           e2eConfig.GetVariable(InPlaceUpgradeOption),
-				MachineDeployments:      result.MachineDeployments,
 			})
 		})
 	})


### PR DESCRIPTION
### Overview
This PR adds the **orchestrated in-place upgrade controller** to the control plane provider.
After annotating the `CK8sControlPlane` object with `inplace-upgrade-to` annotation, this controller will make sure that each control plane machine is upgraded to the specified version.
By design, this controller does not allow parallel upgrades to ensure that the control plane stays responsive (prevent breaking HA, quorum, etc.)

### Details
- A lock (which is just a glorified configMap) prevents multiple control plane nodes getting upgraded
- Some of the common functionality is moved to `pkg/upgrade/inplace`. We should use these functionalities for the `MachineDeploymentReconciler` as well (instead of separately implementing them, which is what we're doing right now).
    - Also the `MachineDeploymentReconciler` should get renamed to resemble its responsibilities more closely (e.g. `bootstrapControllers.OrchestratedInPlaceUpgradeController`) in the future.