### PR TITLE
Use new channel field instead of install script overwrite

### DIFF
--- a/templates/aws/cluster-template.yaml
+++ b/templates/aws/cluster-template.yaml
@@ -51,6 +51,7 @@ spec:
       name: ${CLUSTER_NAME}-control-plane
   spec:
     nodeName: "{{ ds.meta_data.local_hostname }}"
+    # note(ben): This is only required as long as k8s does not have a stable release.
     channel: "1.31-classic/edge"
     controlPlane:
       cloudProvider: external
@@ -121,6 +122,7 @@ spec:
   template:
     spec:
       nodeName: "{{ ds.meta_data.local_hostname }}"
+      # note(ben): This is only required as long as k8s does not have a stable release.
       channel: "1.31-classic/edge"
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1

--- a/templates/aws/cluster-template.yaml
+++ b/templates/aws/cluster-template.yaml
@@ -51,14 +51,7 @@ spec:
       name: ${CLUSTER_NAME}-control-plane
   spec:
     nodeName: "{{ ds.meta_data.local_hostname }}"
-    files:
-      # note(ben): This is only required as long as k8s does not have a stable release.
-      - path: /capi/scripts/install.sh
-        permissions: "0500"
-        owner: "root:root"
-        content: |
-          #!/bin/bash -xe
-          snap install k8s --classic --edge
+    channel: "1.31-classic/edge"
     controlPlane:
       cloudProvider: external
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -128,14 +121,7 @@ spec:
   template:
     spec:
       nodeName: "{{ ds.meta_data.local_hostname }}"
-      files:
-        # note(ben): This is only required as long as k8s does not have a stable release.
-        - path: /capi/scripts/install.sh
-          permissions: "0500"
-          owner: "root:root"
-          content: |
-            #!/bin/bash -xe
-            snap install k8s --classic --edge
+      channel: "1.31-classic/edge"
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet


### PR DESCRIPTION
We now have a channel field we can use to specify the installation channel. This PR removes the install script overwrite and replaces it with the channel field.