### PR TITLE
Add E2E tests for CK8sControlPlane orchestrated in-place upgrades

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,6 +65,7 @@ jobs:
           - "Workload cluster creation"
           - "Workload cluster scaling"
           - "Workload cluster upgrade"
+          - "Orchestrated In place upgrades"
       # TODO(ben): Remove once all tests are running stable.
       fail-fast: false
     steps:

--- a/test/e2e/orchestrated_cp_in_place_upgrade_test.go
+++ b/test/e2e/orchestrated_cp_in_place_upgrade_test.go
@@ -32,10 +32,10 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
+var _ = Describe("CK8sControlPlane Orchestrated In place upgrades", func() {
 	var (
 		ctx                    = context.TODO()
-		specName               = "workload-cluster-md-inplace"
+		specName               = "workload-cluster-ck8scp-inplace"
 		namespace              *corev1.Namespace
 		cancelWatches          context.CancelFunc
 		result                 *ApplyClusterTemplateAndWaitResult
@@ -47,7 +47,7 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 	BeforeEach(func() {
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
 
-		clusterName = fmt.Sprintf("capick8s-md-in-place-%s", util.RandomString(6))
+		clusterName = fmt.Sprintf("capick8s-ck8scp-in-place-%s", util.RandomString(6))
 		infrastructureProvider = clusterctl.DefaultInfrastructureProvider
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
@@ -73,9 +73,9 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 		dumpSpecResourcesAndCleanup(ctx, cleanInput)
 	})
 
-	Context("Performing Machine Deployment Orchestrated in-place upgrades", func() {
-		It("Creating a workload cluster and applying in-place upgrade to Machine Deployment [MD-InPlace] [PR-Blocking]", func() {
-			By("Creating a workload cluster of 1 control plane and 3 worker nodes")
+	Context("Performing CK8sControlPlane Orchestrated in-place upgrades", func() {
+		It("Creating a workload cluster and applying in-place upgrade to CK8sControlPlane [CK8SCP-InPlace] [PR-Blocking]", func() {
+			By("Creating a workload cluster of 3 control plane and 1 worker nodes")
 			ApplyClusterTemplateAndWait(ctx, ApplyClusterTemplateAndWaitInput{
 				ClusterProxy: bootstrapClusterProxy,
 				ConfigCluster: clusterctl.ConfigClusterInput{
@@ -86,8 +86,8 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 					Namespace:                namespace.Name,
 					ClusterName:              clusterName,
 					KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
-					ControlPlaneMachineCount: ptr.To(int64(1)),
-					WorkerMachineCount:       ptr.To(int64(3)),
+					ControlPlaneMachineCount: ptr.To(int64(3)),
+					WorkerMachineCount:       ptr.To(int64(1)),
 				},
 				WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
 				WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
@@ -96,15 +96,14 @@ var _ = Describe("Machine Deployment Orchestrated In place upgrades", func() {
 
 			bootstrapProxyClient := bootstrapClusterProxy.GetClient()
 
-			By("Applying in place upgrade with local path for MachineDeployment object")
-			ApplyInPlaceUpgradeForMachineDeployment(ctx, ApplyInPlaceUpgradeForMachineDeploymentInput{
+			By("Applying in place upgrade with local path for CK8sControlPlane object")
+			ApplyInPlaceUpgradeForCK8sControlPlane(ctx, ApplyInPlaceUpgradeForCK8sControlPlaneInput{
 				Lister:                  bootstrapProxyClient,
 				Getter:                  bootstrapProxyClient,
 				ClusterProxy:            bootstrapClusterProxy,
 				Cluster:                 result.Cluster,
 				WaitForUpgradeIntervals: e2eConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				UpgradeOption:           e2eConfig.GetVariable(InPlaceUpgradeOption),
-				MachineDeployments:      result.MachineDeployments,
 			})
 		})
 	})


### PR DESCRIPTION
### Overview
This PR adds E2E tests for Orchestrated Control Plane In-Place upgrades controller. 
- Also did a minor touch up on the MachineDeployment in-place upgrades controller tests.