### PR TITLE
e2e: Increase runner size

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build-e2e-images:
     name: Build & Run E2E Images
-    runs-on: [self-hosted, linux, X64, jammy, large]
+    runs-on: [self-hosted, linux, X64, jammy, xlarge]
     steps:
       -
         name: Login to GitHub Container Registry


### PR DESCRIPTION
The `Build & Run E2E Images` job has to build various images and snaps for subsequent jobs, and thus, requires a quite a bit of storage. Some of the job failures occur simply because the set self-hosted runner runs out of space.
