### PR TITLE
Add ck8scontrolplane extraSANs to the /capi/etc/config.yaml:extra-sans

### DIFF
--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -122,7 +122,8 @@ func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.Bootstrap
 		}
 	}
 
-	// extra SANs
+	out.ExtraSANs = cfg.ControlPlaneConfig.ExtraSANs
+	// ControlPlaneEndpoint IP should be added to the ExtraSANs
 	out.ExtraSANs = append(out.ExtraSANs, cfg.ControlPlaneEndpoint)
 
 	if v := cfg.ControlPlaneConfig.NodeTaints; len(v) > 0 {


### PR DESCRIPTION
Fixes: https://github.com/canonical/cluster-api-k8s/issues/93