### PR TITLE
Adds non-default ServiceAccount

### DIFF
--- a/bootstrap/config/manager/manager.yaml
+++ b/bootstrap/config/manager/manager.yaml
@@ -29,4 +29,5 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+      serviceAccountName: manager
       terminationGracePeriodSeconds: 10

--- a/bootstrap/config/rbac/auth_proxy_role_binding.yaml
+++ b/bootstrap/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager
   namespace: system

--- a/bootstrap/config/rbac/kustomization.yaml
+++ b/bootstrap/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/bootstrap/config/rbac/leader_election_role_binding.yaml
+++ b/bootstrap/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager
   namespace: system

--- a/bootstrap/config/rbac/role_binding.yaml
+++ b/bootstrap/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager
   namespace: system

--- a/bootstrap/config/rbac/service_account.yaml
+++ b/bootstrap/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager
+  namespace: system

--- a/controlplane/config/manager/manager.yaml
+++ b/controlplane/config/manager/manager.yaml
@@ -29,4 +29,5 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+      serviceAccountName: manager
       terminationGracePeriodSeconds: 10

--- a/controlplane/config/rbac/auth_proxy_role_binding.yaml
+++ b/controlplane/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager
   namespace: system

--- a/controlplane/config/rbac/kustomization.yaml
+++ b/controlplane/config/rbac/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- service_account.yaml
 - role.yaml
 - role_binding.yaml
 - leader_election_role.yaml

--- a/controlplane/config/rbac/leader_election_role_binding.yaml
+++ b/controlplane/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager
   namespace: system

--- a/controlplane/config/rbac/role_binding.yaml
+++ b/controlplane/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager
   namespace: system

--- a/controlplane/config/rbac/service_account.yaml
+++ b/controlplane/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager
+  namespace: system


### PR DESCRIPTION
The CIS 5.1.5 rule specifies: "Ensure that default service accounts are not actively used."

Currently, the default service account is being used. This adds the manager service account, resolving this issue.

Closes: https://github.com/canonical/cluster-api-k8s/issues/88