### PR TITLE
Allow passing extra service args

### DIFF
--- a/bootstrap/api/v1beta2/ck8sconfig_types.go
+++ b/bootstrap/api/v1beta2/ck8sconfig_types.go
@@ -108,6 +108,22 @@ type CK8sConfigSpec struct {
 	// typically set in Jinja template form, e.g."{{ ds.meta_data.local_hostname }}".
 	// +optional
 	NodeName string `json:"nodeName,omitempty"`
+
+	// ExtraKubeProxyArgs - extra arguments to add to kube-proxy.
+	// +optional
+	ExtraKubeProxyArgs map[string]*string `json:"extraKubeProxyArgs,omitempty"`
+
+	// ExtraKubeletArgs - extra arguments to add to kubelet.
+	// +optional
+	ExtraKubeletArgs map[string]*string `json:"extraKubeletArgs,omitempty"`
+
+	// ExtraContainerdArgs - extra arguments to add to containerd.
+	// +optional
+	ExtraContainerdArgs map[string]*string `json:"extraContainerdArgs,omitempty"`
+
+	// ExtraK8sAPIServerProxyArgs - extra arguments to add to k8s-api-server-proxy.
+	// +optional
+	ExtraK8sAPIServerProxyArgs map[string]*string `json:"ExtraK8sAPIServerProxyArgs,omitempty"`
 }
 
 // IsEtcdManaged returns true if the control plane is using k8s-dqlite.
@@ -152,9 +168,21 @@ type CK8sControlPlaneConfig struct {
 	// +optional
 	MicroclusterPort *int `json:"microclusterPort,omitempty"`
 
-	// ExtraKubeAPIServerArgs is extra arguments to add to kube-apiserver.
+	// ExtraKubeAPIServerArgs - extra arguments to add to kube-apiserver.
 	// +optional
 	ExtraKubeAPIServerArgs map[string]*string `json:"extraKubeAPIServerArgs,omitempty"`
+
+	// ExtraKubeControllerManagerArgs - extra arguments to add to kube-controller-manager.
+	// +optional
+	ExtraKubeControllerManagerArgs map[string]*string `json:"extraKubeControllerManagerArgs,omitempty"`
+
+	// ExtraKubeSchedulerArgs - extra arguments to add to kube-scheduler.
+	// +optional
+	ExtraKubeSchedulerArgs map[string]*string `json:"extraKubeSchedulerArgs,omitempty"`
+
+	// ExtraK8sDqliteArgs - extra arguments to add to k8s-dqlite.
+	// +optional
+	ExtraK8sDqliteArgs  map[string]*string `json:"ExtraK8sDqliteArgs,omitempty"`
 }
 
 // GetMicroclusterPort returns the port to use for microcluster.

--- a/bootstrap/api/v1beta2/ck8sconfig_types.go
+++ b/bootstrap/api/v1beta2/ck8sconfig_types.go
@@ -182,7 +182,7 @@ type CK8sControlPlaneConfig struct {
 
 	// ExtraK8sDqliteArgs - extra arguments to add to k8s-dqlite.
 	// +optional
-	ExtraK8sDqliteArgs  map[string]*string `json:"ExtraK8sDqliteArgs,omitempty"`
+	ExtraK8sDqliteArgs map[string]*string `json:"ExtraK8sDqliteArgs,omitempty"`
 }
 
 // GetMicroclusterPort returns the port to use for microcluster.

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
@@ -39,6 +39,12 @@ spec:
           spec:
             description: CK8sConfigSpec defines the desired state of CK8sConfig.
             properties:
+              ExtraK8sAPIServerProxyArgs:
+                additionalProperties:
+                  type: string
+                description: ExtraK8sAPIServerProxyArgs - extra arguments to add to
+                  k8s-api-server-proxy.
+                type: object
               airGapped:
                 description: |-
                   AirGapped is used to signal that we are deploying to an airgap environment. In this case,
@@ -91,6 +97,11 @@ spec:
                 description: CK8sControlPlaneConfig is configuration for the control
                   plane node.
                 properties:
+                  ExtraK8sDqliteArgs:
+                    additionalProperties:
+                      type: string
+                    description: ExtraK8sDqliteArgs - extra arguments to add to k8s-dqlite.
+                    type: object
                   cloudProvider:
                     description: CloudProvider is the cloud-provider configuration
                       option to set.
@@ -117,8 +128,20 @@ spec:
                   extraKubeAPIServerArgs:
                     additionalProperties:
                       type: string
-                    description: ExtraKubeAPIServerArgs is extra arguments to add
-                      to kube-apiserver.
+                    description: ExtraKubeAPIServerArgs - extra arguments to add to
+                      kube-apiserver.
+                    type: object
+                  extraKubeControllerManagerArgs:
+                    additionalProperties:
+                      type: string
+                    description: ExtraKubeControllerManagerArgs - extra arguments
+                      to add to kube-controller-manager.
+                    type: object
+                  extraKubeSchedulerArgs:
+                    additionalProperties:
+                      type: string
+                    description: ExtraKubeSchedulerArgs - extra arguments to add to
+                      kube-scheduler.
                     type: object
                   extraSANs:
                     description: ExtraSANs is a list of SANs to include in the server
@@ -144,6 +167,21 @@ spec:
                     items:
                       type: string
                     type: array
+                type: object
+              extraContainerdArgs:
+                additionalProperties:
+                  type: string
+                description: ExtraContainerdArgs - extra arguments to add to containerd.
+                type: object
+              extraKubeProxyArgs:
+                additionalProperties:
+                  type: string
+                description: ExtraKubeProxyArgs - extra arguments to add to kube-proxy.
+                type: object
+              extraKubeletArgs:
+                additionalProperties:
+                  type: string
+                description: ExtraKubeletArgs - extra arguments to add to kubelet.
                 type: object
               files:
                 description: Files specifies extra files to be passed to user_data

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
@@ -46,6 +46,12 @@ spec:
                   spec:
                     description: CK8sConfigSpec defines the desired state of CK8sConfig.
                     properties:
+                      ExtraK8sAPIServerProxyArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraK8sAPIServerProxyArgs - extra arguments
+                          to add to k8s-api-server-proxy.
+                        type: object
                       airGapped:
                         description: |-
                           AirGapped is used to signal that we are deploying to an airgap environment. In this case,
@@ -98,6 +104,12 @@ spec:
                         description: CK8sControlPlaneConfig is configuration for the
                           control plane node.
                         properties:
+                          ExtraK8sDqliteArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraK8sDqliteArgs - extra arguments to add
+                              to k8s-dqlite.
+                            type: object
                           cloudProvider:
                             description: CloudProvider is the cloud-provider configuration
                               option to set.
@@ -124,8 +136,20 @@ spec:
                           extraKubeAPIServerArgs:
                             additionalProperties:
                               type: string
-                            description: ExtraKubeAPIServerArgs is extra arguments
+                            description: ExtraKubeAPIServerArgs - extra arguments
                               to add to kube-apiserver.
+                            type: object
+                          extraKubeControllerManagerArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraKubeControllerManagerArgs - extra arguments
+                              to add to kube-controller-manager.
+                            type: object
+                          extraKubeSchedulerArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraKubeSchedulerArgs - extra arguments
+                              to add to kube-scheduler.
                             type: object
                           extraSANs:
                             description: ExtraSANs is a list of SANs to include in
@@ -152,6 +176,24 @@ spec:
                             items:
                               type: string
                             type: array
+                        type: object
+                      extraContainerdArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraContainerdArgs - extra arguments to add
+                          to containerd.
+                        type: object
+                      extraKubeProxyArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraKubeProxyArgs - extra arguments to add to
+                          kube-proxy.
+                        type: object
+                      extraKubeletArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraKubeletArgs - extra arguments to add to
+                          kubelet.
                         type: object
                       files:
                         description: Files specifies extra files to be passed to user_data

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -247,8 +247,8 @@ func (r *CK8sConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 		ControlPlaneEndpoint: scope.Cluster.Spec.ControlPlaneEndpoint.Host,
 		ControlPlaneConfig:   controlPlaneConfig,
 
-		ExtraKubeProxyArgs: scope.Config.Spec.ExtraKubeProxyArgs,
-		ExtraKubeletArgs: scope.Config.Spec.ExtraKubeletArgs,
+		ExtraKubeProxyArgs:  scope.Config.Spec.ExtraKubeProxyArgs,
+		ExtraKubeletArgs:    scope.Config.Spec.ExtraKubeletArgs,
 		ExtraContainerdArgs: scope.Config.Spec.ExtraContainerdArgs,
 	})
 	joinConfig, err := kubeyaml.Marshal(configStruct)
@@ -349,9 +349,9 @@ func (r *CK8sConfigReconciler) joinWorker(ctx context.Context, scope *Scope) err
 	}
 
 	configStruct := ck8s.GenerateJoinWorkerConfig(ck8s.JoinWorkerConfig{
-		ExtraKubeProxyArgs: scope.Config.Spec.ExtraKubeProxyArgs,
-		ExtraKubeletArgs: scope.Config.Spec.ExtraKubeletArgs,
-		ExtraContainerdArgs: scope.Config.Spec.ExtraContainerdArgs,
+		ExtraKubeProxyArgs:         scope.Config.Spec.ExtraKubeProxyArgs,
+		ExtraKubeletArgs:           scope.Config.Spec.ExtraKubeletArgs,
+		ExtraContainerdArgs:        scope.Config.Spec.ExtraContainerdArgs,
 		ExtraK8sAPIServerProxyArgs: scope.Config.Spec.ExtraK8sAPIServerProxyArgs,
 	})
 	joinConfig, err := kubeyaml.Marshal(configStruct)
@@ -647,9 +647,9 @@ func (r *CK8sConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 
 		ClusterNetwork: scope.Cluster.Spec.ClusterNetwork,
 
-		ExtraKubeProxyArgs: scope.Config.Spec.ExtraKubeProxyArgs,
-		ExtraKubeletArgs: scope.Config.Spec.ExtraKubeletArgs,
-		ExtraContainerdArgs: scope.Config.Spec.ExtraContainerdArgs,
+		ExtraKubeProxyArgs:         scope.Config.Spec.ExtraKubeProxyArgs,
+		ExtraKubeletArgs:           scope.Config.Spec.ExtraKubeletArgs,
+		ExtraContainerdArgs:        scope.Config.Spec.ExtraContainerdArgs,
 		ExtraK8sAPIServerProxyArgs: scope.Config.Spec.ExtraK8sAPIServerProxyArgs,
 	}
 

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -246,6 +246,10 @@ func (r *CK8sConfigReconciler) joinControlplane(ctx context.Context, scope *Scop
 	configStruct := ck8s.GenerateJoinControlPlaneConfig(ck8s.JoinControlPlaneConfig{
 		ControlPlaneEndpoint: scope.Cluster.Spec.ControlPlaneEndpoint.Host,
 		ControlPlaneConfig:   controlPlaneConfig,
+
+		ExtraKubeProxyArgs: scope.Config.Spec.ExtraKubeProxyArgs,
+		ExtraKubeletArgs: scope.Config.Spec.ExtraKubeletArgs,
+		ExtraContainerdArgs: scope.Config.Spec.ExtraContainerdArgs,
 	})
 	joinConfig, err := kubeyaml.Marshal(configStruct)
 	if err != nil {
@@ -344,7 +348,12 @@ func (r *CK8sConfigReconciler) joinWorker(ctx context.Context, scope *Scope) err
 		return fmt.Errorf("failed to request join token: %w", err)
 	}
 
-	configStruct := ck8s.GenerateJoinWorkerConfig(ck8s.JoinWorkerConfig{})
+	configStruct := ck8s.GenerateJoinWorkerConfig(ck8s.JoinWorkerConfig{
+		ExtraKubeProxyArgs: scope.Config.Spec.ExtraKubeProxyArgs,
+		ExtraKubeletArgs: scope.Config.Spec.ExtraKubeletArgs,
+		ExtraContainerdArgs: scope.Config.Spec.ExtraContainerdArgs,
+		ExtraK8sAPIServerProxyArgs: scope.Config.Spec.ExtraK8sAPIServerProxyArgs,
+	})
 	joinConfig, err := kubeyaml.Marshal(configStruct)
 	if err != nil {
 		return err
@@ -637,6 +646,11 @@ func (r *CK8sConfigReconciler) handleClusterNotInitialized(ctx context.Context, 
 		InitConfig:            scope.Config.Spec.InitConfig,
 
 		ClusterNetwork: scope.Cluster.Spec.ClusterNetwork,
+
+		ExtraKubeProxyArgs: scope.Config.Spec.ExtraKubeProxyArgs,
+		ExtraKubeletArgs: scope.Config.Spec.ExtraKubeletArgs,
+		ExtraContainerdArgs: scope.Config.Spec.ExtraContainerdArgs,
+		ExtraK8sAPIServerProxyArgs: scope.Config.Spec.ExtraK8sAPIServerProxyArgs,
 	}
 
 	if !scope.Config.Spec.IsEtcdManaged() {

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
@@ -234,6 +234,12 @@ spec:
                   CK8sConfigSpec is a CK8sConfigSpec
                   to use for initializing and joining machines to the control plane.
                 properties:
+                  ExtraK8sAPIServerProxyArgs:
+                    additionalProperties:
+                      type: string
+                    description: ExtraK8sAPIServerProxyArgs - extra arguments to add
+                      to k8s-api-server-proxy.
+                    type: object
                   airGapped:
                     description: |-
                       AirGapped is used to signal that we are deploying to an airgap environment. In this case,
@@ -286,6 +292,12 @@ spec:
                     description: CK8sControlPlaneConfig is configuration for the control
                       plane node.
                     properties:
+                      ExtraK8sDqliteArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraK8sDqliteArgs - extra arguments to add to
+                          k8s-dqlite.
+                        type: object
                       cloudProvider:
                         description: CloudProvider is the cloud-provider configuration
                           option to set.
@@ -312,8 +324,20 @@ spec:
                       extraKubeAPIServerArgs:
                         additionalProperties:
                           type: string
-                        description: ExtraKubeAPIServerArgs is extra arguments to
-                          add to kube-apiserver.
+                        description: ExtraKubeAPIServerArgs - extra arguments to add
+                          to kube-apiserver.
+                        type: object
+                      extraKubeControllerManagerArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraKubeControllerManagerArgs - extra arguments
+                          to add to kube-controller-manager.
+                        type: object
+                      extraKubeSchedulerArgs:
+                        additionalProperties:
+                          type: string
+                        description: ExtraKubeSchedulerArgs - extra arguments to add
+                          to kube-scheduler.
                         type: object
                       extraSANs:
                         description: ExtraSANs is a list of SANs to include in the
@@ -340,6 +364,21 @@ spec:
                         items:
                           type: string
                         type: array
+                    type: object
+                  extraContainerdArgs:
+                    additionalProperties:
+                      type: string
+                    description: ExtraContainerdArgs - extra arguments to add to containerd.
+                    type: object
+                  extraKubeProxyArgs:
+                    additionalProperties:
+                      type: string
+                    description: ExtraKubeProxyArgs - extra arguments to add to kube-proxy.
+                    type: object
+                  extraKubeletArgs:
+                    additionalProperties:
+                      type: string
+                    description: ExtraKubeletArgs - extra arguments to add to kubelet.
                     type: object
                   files:
                     description: Files specifies extra files to be passed to user_data

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
@@ -209,6 +209,12 @@ spec:
                           CK8sConfigSpec is a CK8sConfigSpec
                           to use for initializing and joining machines to the control plane.
                         properties:
+                          ExtraK8sAPIServerProxyArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraK8sAPIServerProxyArgs - extra arguments
+                              to add to k8s-api-server-proxy.
+                            type: object
                           airGapped:
                             description: |-
                               AirGapped is used to signal that we are deploying to an airgap environment. In this case,
@@ -262,6 +268,12 @@ spec:
                             description: CK8sControlPlaneConfig is configuration for
                               the control plane node.
                             properties:
+                              ExtraK8sDqliteArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraK8sDqliteArgs - extra arguments
+                                  to add to k8s-dqlite.
+                                type: object
                               cloudProvider:
                                 description: CloudProvider is the cloud-provider configuration
                                   option to set.
@@ -288,8 +300,20 @@ spec:
                               extraKubeAPIServerArgs:
                                 additionalProperties:
                                   type: string
-                                description: ExtraKubeAPIServerArgs is extra arguments
+                                description: ExtraKubeAPIServerArgs - extra arguments
                                   to add to kube-apiserver.
+                                type: object
+                              extraKubeControllerManagerArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraKubeControllerManagerArgs - extra
+                                  arguments to add to kube-controller-manager.
+                                type: object
+                              extraKubeSchedulerArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraKubeSchedulerArgs - extra arguments
+                                  to add to kube-scheduler.
                                 type: object
                               extraSANs:
                                 description: ExtraSANs is a list of SANs to include
@@ -317,6 +341,24 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                            type: object
+                          extraContainerdArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraContainerdArgs - extra arguments to
+                              add to containerd.
+                            type: object
+                          extraKubeProxyArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraKubeProxyArgs - extra arguments to add
+                              to kube-proxy.
+                            type: object
+                          extraKubeletArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraKubeletArgs - extra arguments to add
+                              to kubelet.
                             type: object
                           files:
                             description: Files specifies extra files to be passed

--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -22,6 +22,11 @@ type InitControlPlaneConfig struct {
 	DatastoreServers      []string
 
 	ClusterNetwork *clusterv1.ClusterNetwork
+
+	ExtraKubeProxyArgs map[string]*string
+	ExtraKubeletArgs map[string]*string
+	ExtraContainerdArgs map[string]*string
+	ExtraK8sAPIServerProxyArgs map[string]*string
 }
 
 func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.BootstrapConfig, error) {
@@ -130,6 +135,13 @@ func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.Bootstrap
 	}
 
 	out.ExtraNodeKubeAPIServerArgs = cfg.ControlPlaneConfig.ExtraKubeAPIServerArgs
+	out.ExtraNodeKubeControllerManagerArgs = cfg.ControlPlaneConfig.ExtraKubeControllerManagerArgs
+	out.ExtraNodeKubeSchedulerArgs = cfg.ControlPlaneConfig.ExtraKubeSchedulerArgs
+	out.ExtraNodeK8sDqliteArgs = cfg.ControlPlaneConfig.ExtraK8sDqliteArgs
+
+	out.ExtraNodeKubeProxyArgs = cfg.ExtraKubeProxyArgs
+	out.ExtraNodeKubeletArgs = cfg.ExtraKubeletArgs
+	out.ExtraNodeContainerdArgs = cfg.ExtraContainerdArgs
 
 	return out, nil
 }

--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -23,9 +23,9 @@ type InitControlPlaneConfig struct {
 
 	ClusterNetwork *clusterv1.ClusterNetwork
 
-	ExtraKubeProxyArgs map[string]*string
-	ExtraKubeletArgs map[string]*string
-	ExtraContainerdArgs map[string]*string
+	ExtraKubeProxyArgs         map[string]*string
+	ExtraKubeletArgs           map[string]*string
+	ExtraContainerdArgs        map[string]*string
 	ExtraK8sAPIServerProxyArgs map[string]*string
 }
 

--- a/pkg/ck8s/config_join.go
+++ b/pkg/ck8s/config_join.go
@@ -10,8 +10,8 @@ type JoinControlPlaneConfig struct {
 	ControlPlaneEndpoint string
 	ControlPlaneConfig   bootstrapv1.CK8sControlPlaneConfig
 
-	ExtraKubeProxyArgs map[string]*string
-	ExtraKubeletArgs map[string]*string
+	ExtraKubeProxyArgs  map[string]*string
+	ExtraKubeletArgs    map[string]*string
 	ExtraContainerdArgs map[string]*string
 }
 
@@ -19,29 +19,29 @@ func GenerateJoinControlPlaneConfig(cfg JoinControlPlaneConfig) apiv1.ControlPla
 	return apiv1.ControlPlaneJoinConfig{
 		ExtraSANS: append(cfg.ControlPlaneConfig.ExtraSANs, cfg.ControlPlaneEndpoint),
 
-		ExtraNodeKubeAPIServerArgs: cfg.ControlPlaneConfig.ExtraKubeAPIServerArgs,
+		ExtraNodeKubeAPIServerArgs:         cfg.ControlPlaneConfig.ExtraKubeAPIServerArgs,
 		ExtraNodeKubeControllerManagerArgs: cfg.ControlPlaneConfig.ExtraKubeControllerManagerArgs,
-		ExtraNodeKubeSchedulerArgs: cfg.ControlPlaneConfig.ExtraKubeSchedulerArgs,
-		ExtraNodeK8sDqliteArgs: cfg.ControlPlaneConfig.ExtraK8sDqliteArgs,
+		ExtraNodeKubeSchedulerArgs:         cfg.ControlPlaneConfig.ExtraKubeSchedulerArgs,
+		ExtraNodeK8sDqliteArgs:             cfg.ControlPlaneConfig.ExtraK8sDqliteArgs,
 
-		ExtraNodeKubeProxyArgs: cfg.ExtraKubeProxyArgs,
-		ExtraNodeKubeletArgs: cfg.ExtraKubeletArgs,
+		ExtraNodeKubeProxyArgs:  cfg.ExtraKubeProxyArgs,
+		ExtraNodeKubeletArgs:    cfg.ExtraKubeletArgs,
 		ExtraNodeContainerdArgs: cfg.ExtraContainerdArgs,
 	}
 }
 
 type JoinWorkerConfig struct {
-	ExtraKubeProxyArgs map[string]*string
-	ExtraKubeletArgs map[string]*string
-	ExtraContainerdArgs map[string]*string
+	ExtraKubeProxyArgs         map[string]*string
+	ExtraKubeletArgs           map[string]*string
+	ExtraContainerdArgs        map[string]*string
 	ExtraK8sAPIServerProxyArgs map[string]*string
 }
 
 func GenerateJoinWorkerConfig(cfg JoinWorkerConfig) apiv1.WorkerJoinConfig {
 	return apiv1.WorkerJoinConfig{
-		ExtraNodeKubeProxyArgs: cfg.ExtraKubeProxyArgs,
-		ExtraNodeKubeletArgs: cfg.ExtraKubeletArgs,
-		ExtraNodeContainerdArgs: cfg.ExtraContainerdArgs,
+		ExtraNodeKubeProxyArgs:         cfg.ExtraKubeProxyArgs,
+		ExtraNodeKubeletArgs:           cfg.ExtraKubeletArgs,
+		ExtraNodeContainerdArgs:        cfg.ExtraContainerdArgs,
 		ExtraNodeK8sAPIServerProxyArgs: cfg.ExtraK8sAPIServerProxyArgs,
 	}
 }

--- a/pkg/ck8s/config_join.go
+++ b/pkg/ck8s/config_join.go
@@ -10,7 +10,9 @@ type JoinControlPlaneConfig struct {
 	ControlPlaneEndpoint string
 	ControlPlaneConfig   bootstrapv1.CK8sControlPlaneConfig
 
-	ExtraKubeAPIServerArgs map[string]*string
+	ExtraKubeProxyArgs map[string]*string
+	ExtraKubeletArgs map[string]*string
+	ExtraContainerdArgs map[string]*string
 }
 
 func GenerateJoinControlPlaneConfig(cfg JoinControlPlaneConfig) apiv1.ControlPlaneJoinConfig {
@@ -18,12 +20,28 @@ func GenerateJoinControlPlaneConfig(cfg JoinControlPlaneConfig) apiv1.ControlPla
 		ExtraSANS: append(cfg.ControlPlaneConfig.ExtraSANs, cfg.ControlPlaneEndpoint),
 
 		ExtraNodeKubeAPIServerArgs: cfg.ControlPlaneConfig.ExtraKubeAPIServerArgs,
+		ExtraNodeKubeControllerManagerArgs: cfg.ControlPlaneConfig.ExtraKubeControllerManagerArgs,
+		ExtraNodeKubeSchedulerArgs: cfg.ControlPlaneConfig.ExtraKubeSchedulerArgs,
+		ExtraNodeK8sDqliteArgs: cfg.ControlPlaneConfig.ExtraK8sDqliteArgs,
+
+		ExtraNodeKubeProxyArgs: cfg.ExtraKubeProxyArgs,
+		ExtraNodeKubeletArgs: cfg.ExtraKubeletArgs,
+		ExtraNodeContainerdArgs: cfg.ExtraContainerdArgs,
 	}
 }
 
 type JoinWorkerConfig struct {
+	ExtraKubeProxyArgs map[string]*string
+	ExtraKubeletArgs map[string]*string
+	ExtraContainerdArgs map[string]*string
+	ExtraK8sAPIServerProxyArgs map[string]*string
 }
 
 func GenerateJoinWorkerConfig(cfg JoinWorkerConfig) apiv1.WorkerJoinConfig {
-	return apiv1.WorkerJoinConfig{}
+	return apiv1.WorkerJoinConfig{
+		ExtraNodeKubeProxyArgs: cfg.ExtraKubeProxyArgs,
+		ExtraNodeKubeletArgs: cfg.ExtraKubeletArgs,
+		ExtraNodeContainerdArgs: cfg.ExtraContainerdArgs,
+		ExtraNodeK8sAPIServerProxyArgs: cfg.ExtraK8sAPIServerProxyArgs,
+	}
 }


### PR DESCRIPTION
The CAPI provider already allows passing extra kube-api args.

We'll do the same for the other k8s services (e.g. kubelet, kube-proxy, containerd, dqlite, etc), exposing the corresponding k8s-snap settings.

Fixes: https://github.com/canonical/cluster-api-k8s/issues/91