### PR TITLE
docs: Add pre-release steps and docs

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,13 @@
+# How to cut a CAPI provider release
+
+For `minor` releases you need to do the following pre-release steps:
+
+1. Add the new release with the corresponding CAPI contract to [the metadata file](../metadata.yaml)
+2. Update the integration test files with the latest minor version:
+    * https://github.com/canonical/cluster-api-k8s/blob/91e4fe70dfb7aaa357396d62c84f0d60de45595f/test/e2e/config/ck8s-docker.yaml#66
+    * https://github.com/canonical/cluster-api-k8s/blob/91e4fe70dfb7aaa357396d62c84f0d60de45595f/test/e2e/config/ck8s-docker.yaml#77
+    * https://github.com/canonical/cluster-api-k8s/blob/91e4fe70dfb7aaa357396d62c84f0d60de45595f/test/e2e/config/ck8s-aws.yaml#L64
+    * https://github.com/canonical/cluster-api-k8s/blob/91e4fe70dfb7aaa357396d62c84f0d60de45595f/test/e2e/config/ck8s-aws.yaml#L74
+
+Now, for `minor` and `patch` releases alike, you only need to create a new tag `vX.Y.ZZ` or `vX.Y.ZZ-rcABC` for release candidates.
+The [Github workflow](https://github.com/canonical/cluster-api-k8s/blob/main/.github/workflows/release.yaml#L7) will then automatically create the release packages and add a new release to Github.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,3 +7,6 @@ releaseSeries:
   - major: 0
     minor: 2
     contract: v1beta1
+  - major: 0
+    minor: 3
+    contract: v1beta1

--- a/test/e2e/config/ck8s-aws.yaml
+++ b/test/e2e/config/ck8s-aws.yaml
@@ -61,7 +61,7 @@ providers:
       # ${ProjectRoot}/metadata.yaml to init the management cluster
       # this version should be updated when ${ProjectRoot}/metadata.yaml
       # is modified
-      - name: v0.2.99 # next; use manifest from source files
+      - name: v0.3.99 # next; use manifest from source files
         value: "../../../bootstrap/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/bootstrap-controller:latest"
@@ -71,7 +71,7 @@ providers:
   - name: ck8s
     type: ControlPlaneProvider
     versions:
-      - name: v0.2.99 # next; use manifest from source files
+      - name: v0.3.99 # next; use manifest from source files
         value: "../../../controlplane/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/controlplane-controller:latest"

--- a/test/e2e/config/ck8s-docker.yaml
+++ b/test/e2e/config/ck8s-docker.yaml
@@ -63,7 +63,7 @@ providers:
       # ${ProjectRoot}/metadata.yaml to init the management cluster
       # this version should be updated when ${ProjectRoot}/metadata.yaml
       # is modified
-      - name: v0.2.99 # next; use manifest from source files
+      - name: v0.3.99 # next; use manifest from source files
         value: "../../../bootstrap/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/bootstrap-controller:latest"
@@ -74,7 +74,7 @@ providers:
   - name: ck8s
     type: ControlPlaneProvider
     versions:
-      - name: v0.2.99 # next; use manifest from source files
+      - name: v0.3.99 # next; use manifest from source files
         value: "../../../controlplane/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/controlplane-controller:latest"


### PR DESCRIPTION
Adds a brief tutorial on what to do for the CAPI provider release.
Does the actual updates for `0.3.0`