### PR TITLE
Fixes local snap installation

### DIFF
--- a/pkg/cloudinit/scripts/install.sh
+++ b/pkg/cloudinit/scripts/install.sh
@@ -13,7 +13,7 @@ elif [ -f "/capi/etc/snap-revision" ]; then
   snap install k8s --classic --revision "${snap_revision}"
 elif [ -f "/capi/etc/snap-local-path" ]; then
   snap_local_path="$(cat /capi/etc/snap-local-path)"
-  snap install k8s --classic --dangerous "${snap_local_path}"
+  snap install --classic --dangerous "${snap_local_path}"
 else
   echo "No snap installation option found"
   exit 1


### PR DESCRIPTION
The snap installation command for the local snap path is incorrect.

Closes: https://github.com/canonical/cluster-api-k8s/issues/105