### PR TITLE
Allow multiple local path snaps to be installed

### DIFF
--- a/bootstrap/api/v1beta2/ck8sconfig_types.go
+++ b/bootstrap/api/v1beta2/ck8sconfig_types.go
@@ -90,7 +90,7 @@ type CK8sConfigSpec struct {
 	// +optional
 	Revision string `json:"revision,omitempty"`
 
-	// LocalPath is the path of a local snap file in the workload cluster to use for the snap install.
+	// LocalPath is the path of a local snap file (or a folder containing local snap files) in the workload cluster to use for the snap install.
 	// If Channel or Revision are set, this will be ignored.
 	// +optional
 	LocalPath string `json:"localPath,omitempty"`

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
@@ -286,7 +286,7 @@ spec:
                 type: object
               localPath:
                 description: |-
-                  LocalPath is the path of a local snap file in the workload cluster to use for the snap install.
+                  LocalPath is the path of a local snap file (or a folder containing local snap files) in the workload cluster to use for the snap install.
                   If Channel or Revision are set, this will be ignored.
                 type: string
               noProxy:

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
@@ -299,7 +299,7 @@ spec:
                         type: object
                       localPath:
                         description: |-
-                          LocalPath is the path of a local snap file in the workload cluster to use for the snap install.
+                          LocalPath is the path of a local snap file (or a folder containing local snap files) in the workload cluster to use for the snap install.
                           If Channel or Revision are set, this will be ignored.
                         type: string
                       noProxy:

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
@@ -484,7 +484,7 @@ spec:
                     type: object
                   localPath:
                     description: |-
-                      LocalPath is the path of a local snap file in the workload cluster to use for the snap install.
+                      LocalPath is the path of a local snap file (or a folder containing local snap files) in the workload cluster to use for the snap install.
                       If Channel or Revision are set, this will be ignored.
                     type: string
                   noProxy:

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
@@ -465,7 +465,7 @@ spec:
                             type: object
                           localPath:
                             description: |-
-                              LocalPath is the path of a local snap file in the workload cluster to use for the snap install.
+                              LocalPath is the path of a local snap file (or a folder containing local snap files) in the workload cluster to use for the snap install.
                               If Channel or Revision are set, this will be ignored.
                             type: string
                           noProxy:

--- a/pkg/cloudinit/scripts/install.sh
+++ b/pkg/cloudinit/scripts/install.sh
@@ -3,7 +3,8 @@
 ## Assumptions:
 ## - /capi/etc/snap-channel contains the snap channel to be installed that matches the desired Kubernetes version, e.g. "v1.30.1" -> "1.30-classic/stable"
 ## - /capi/etc/snap-revision contains the snap revision to be installed, e.g. 123
-## - /capi/etc/snap-local-path contains the path to the local snap file to be installed, e.g. /path/to/k8s.snap
+## - /capi/etc/snap-local-path contains the path to the local snap file to be installed (e.g. /path/to/k8s.snap),
+##   or the path to a folder containing the local snap files to be installed (e.g. /path/to)
 
 if [ -f "/capi/etc/snap-channel" ]; then
   snap_channel="$(cat /capi/etc/snap-channel)"
@@ -13,7 +14,13 @@ elif [ -f "/capi/etc/snap-revision" ]; then
   snap install k8s --classic --revision "${snap_revision}"
 elif [ -f "/capi/etc/snap-local-path" ]; then
   snap_local_path="$(cat /capi/etc/snap-local-path)"
-  snap install --classic --dangerous "${snap_local_path}"
+  snap_local_paths=( "${snap_local_path}" )
+
+  # If $snap_local_path is a folder, install all the snaps from that folder.
+  if [[ -d "${snap_local_path}" ]]; then
+    snap_local_paths=($(ls ${snap_local_path}/*.snap))
+  fi
+  snap install --classic --dangerous "${snap_local_paths[@]}"
 else
   echo "No snap installation option found"
   exit 1


### PR DESCRIPTION
In airgapped environments, multiple snaps may be downloaded and then installed from local paths. The ``k8s`` snap depends on ``core20`` snap.

With this change, /capi/etc/snap-local-path may be a folder containing local snaps to install. This change preserved the old behaviour.

Fixes: https://github.com/canonical/cluster-api-k8s/issues/104