### PR TITLE
ci: add top level permissions to the stale job

### DIFF
--- a/.github/workflows/stale-cron.yaml
+++ b/.github/workflows/stale-cron.yaml
@@ -6,6 +6,9 @@ on:
     paths:
       - .github/workflows/stale-cron.yaml
 
+permissions:
+  contents: read
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We're getting code scanning alerts as the stale job doesn't
contain explicit top-level permissions.
