### PR TITLE
bug: fix CK8sInitConfiguration defaults

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,3 +112,10 @@ jobs:
       - name: Run e2e tests
         run: |
           sudo GINKGO_FOCUS="${{ matrix.ginkgo_focus }}" SKIP_RESOURCE_CLEANUP=true make test-e2e
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-artifacts-${{ github.run_id }}-${{ env.RANDOM_STRING }}-${{ matrix.ginkgo_focus }}
+          path: _artifacts

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,7 +112,10 @@ jobs:
       - name: Run e2e tests
         run: |
           sudo GINKGO_FOCUS="${{ matrix.ginkgo_focus }}" SKIP_RESOURCE_CLEANUP=true make test-e2e
-
+      - name: Change artifact permissions
+        if: always()
+        run: |
+          sudo chown -R $USER _artifacts
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/bootstrap/api/v1beta2/ck8sconfig_types.go
+++ b/bootstrap/api/v1beta2/ck8sconfig_types.go
@@ -239,28 +239,28 @@ func (c *CK8sInitConfiguration) GetEnableDefaultDNS() bool {
 }
 
 // GetEnableDefaultLoadBalancer returns the EnableDefaultLoadBalancer field.
-// If the field is not set, it returns true.
+// If the field is not set, it returns the value of GetEnableDefaultNetwork.
 func (c *CK8sInitConfiguration) GetEnableDefaultLoadBalancer() bool {
 	if c.EnableDefaultLoadBalancer == nil {
-		return true
+		return c.GetEnableDefaultNetwork()
 	}
 	return *c.EnableDefaultLoadBalancer
 }
 
 // GetEnableDefaultGateway returns the EnableDefaultGateway field.
-// If the field is not set, it returns true.
+// If the field is not set, it returns the value of GetEnableDefaultNetwork.
 func (c *CK8sInitConfiguration) GetEnableDefaultGateway() bool {
 	if c.EnableDefaultGateway == nil {
-		return true
+		return c.GetEnableDefaultNetwork()
 	}
 	return *c.EnableDefaultGateway
 }
 
 // GetEnableDefaultIngress returns the EnableDefaultIngress field.
-// If the field is not set, it returns true.
+// If the field is not set, it returns the value of GetEnableDefaultNetwork.
 func (c *CK8sInitConfiguration) GetEnableDefaultIngress() bool {
 	if c.EnableDefaultIngress == nil {
-		return true
+		return c.GetEnableDefaultNetwork()
 	}
 	return *c.EnableDefaultIngress
 }

--- a/pkg/cloudinit/common.go
+++ b/pkg/cloudinit/common.go
@@ -35,11 +35,12 @@ type BaseUserData struct {
 	PreRunCommands []string
 	// PostRunCommands is a list of commands to run after k8s installation.
 	PostRunCommands []string
-	// BootstrapConfig is the contents of the bootstrap configuration file.
+	// BootstrapConfig is the user supplied bootstrap configuration, taking
+	// precedence over ConfigFileContents.
 	BootstrapConfig string
 	// ExtraFiles is a list of extra files to load on the host.
 	ExtraFiles []File
-	// ConfigFileContents is the contents of the k8s configuration file.
+	// ConfigFileContents is the generated bootstrap configuration.
 	ConfigFileContents string
 	// AirGapped declares that a custom installation script is to be used.
 	AirGapped bool


### PR DESCRIPTION
The following settings are enabled by default even if the network feature is disabled:

* EnableDefaultGateway
* EnableDefaultLoadBalancer
* EnableDefaultIngress

This causes bootstrap failures if the network feature is disabled.

To address this, we'll set these default values based on the network feature.

While at it, we'll fix the "BaseUserData" docstrings, clarifying the difference between the "BootstrapConfig" and "ConfigFileContents" fields.

Fixes: https://github.com/canonical/cluster-api-k8s/issues/106