### PR TITLE
Add Openstack templates

### DIFF
--- a/templates/openstack/README.md
+++ b/templates/openstack/README.md
@@ -1,0 +1,182 @@
+# About
+
+This template can be used to deploy Canonical Kubernetes on OpenStack using
+the [CAPO provider].
+
+Unlike the templates from the CAPO repository, it uses the Canonical Kubernetes
+providers instead of Kubeadm.
+
+# Configuration
+
+The templates use the following variables:
+
+| Variable | Description |
+|-|-|
+| KUBERNETES_VERSION | The Kubernets version of the cluster, e.g. "v1.32.2". |
+| CONTROL_PLANE_MACHINE_COUNT | The number of control plane nodes. |
+| WORKER_MACHINE_COUNT | The number of worker nodes. |
+| OPENSTACK_SSH_KEY_NAME | The keypair used to access Openstack instances. |
+| OPENSTACK_IMAGE_NAME | The Openstack image used when deploying Canonical K8s nodes. |
+| OPENSTACK_EXTERNAL_NETWORK_ID | The external Openstack network id. |
+| OPENSTACK_CLOUD | The name of the cloud from the [clouds.yaml] file. |
+| OPENSTACK_CLOUD_YAML_B64 | Base64 encoded [clouds.yaml] file, containing Openstack credentials. |
+| OPENSTACK_CLOUD_CONFIG_B64 | Base64 encoded [Openstack Cloud Controller Manager] configuration. |
+| OPENSTACK_CLOUD_CACERT_B64 | Optional: base64 encoded CA certificate used to contact Openstack services. |
+| OPENSTACK_ENABLE_APISERVER_LOADBALANCER | Set to "true" to use Octavia load balancers. |
+| OPENSTACK_FAILURE_DOMAIN | The OpenStack Nova availability zone. |
+| OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR | The Opentack flavor used to deploy control plane nodes. |
+| OPENSTACK_NODE_MACHINE_FLAVOR | The Opentack flavor used to deploy worker nodes. |
+| OPENSTACK_DNS_NAMESERVERS | The list of DNS nameservers to use for Openstack instances. |
+
+Feel free to use the [template-varaibles.rc] template to define the environment variables or
+[template-variables-devstack.rc] for [Devstack] environments.
+
+# Devstack
+
+[Devstack] can be used to quickly set up an Openstack environment for testing or
+development purposes. We recommend using a clean virtual machine with nested virtualization
+enabled.
+
+Start by cloning the devstack repository:
+
+```
+git clone https://github.com/openstack/devstack
+```
+
+Prepare the Devstack configuration file:
+
+```
+cd devstack
+
+cat <<EOF > local.sh
+[[local|localrc]]
+ADMIN_PASSWORD=secret
+DATABASE_PASSWORD=\$ADMIN_PASSWORD
+RABBIT_PASSWORD=\$ADMIN_PASSWORD
+SERVICE_PASSWORD=\$ADMIN_PASSWORD
+
+IP_VERSION=4
+EOF
+```
+
+Octavia (Load-Balancer-as-a-Service) can be enabled like so:
+
+```
+cat <<EOF >> local.sh
+
+IP_VERSION=4
+
+# Octavia (LoadBalancer-as-a-Service) settings.
+GIT_BASE=https://opendev.org
+enable_plugin neutron $GIT_BASE/openstack/neutron
+enable_plugin octavia \$GIT_BASE/openstack/octavia master
+enable_plugin ovn-octavia-provider \$GIT_BASE/openstack/ovn-octavia-provider
+enable_service octavia o-api o-cw o-hm o-hk o-da
+```
+
+Run ``./stack.sh`` to initialize the OpenStack environment using Devstack.
+
+## CAPI prerequisites
+
+Start by installing [Kind] and [clusterctl].
+
+The CAPO provider relies on the Openstack Resource Controller, which can be
+installed like so:
+
+```
+kubectl apply -f https://github.com/k-orc/openstack-resource-controller/releases/latest/download/install.yaml
+```
+
+Initialize the CAPI providers:
+
+```
+clusterctl init -i openstack -b canonical-kubernetes -c canonical-kubernetes
+```
+
+## Define the template variables
+
+For Devstack environments, [template-variables-devstack.rc] can be used to
+automatically set all the variables required by the Openstack template.
+
+First, make sure to source the Devstack ``openrc`` file. For testing purposes,
+we are going to use admin credentials.
+
+```
+source $devstackDir/openrc admin admin
+```
+
+By default, it will create an Openstack image using Ubuntu 24.04 (noble).
+It also creates an Openstack keypair, expecting a ssh public key at ``~/.ssh/id_rsa.pub``,
+use the ``$SSH_PUBKEY`` variable to specify a different path.
+
+The script checks if Octavia is enabled and sets the corresponding template variables.
+
+## Create the cluster
+
+Source [template-variables-devstack.rc]:
+
+```
+source ./templates/openstack/template-variables-devstack.rc
+```
+
+Generate the manifests:
+
+```
+clusterctl generate cluster c1 --from ./templates/openstack/cluster-template.yaml  > c1.yaml
+```
+
+Create the workload cluster:
+
+```
+kubectl apply -f c1.yaml
+```
+
+## Verifying the deployment
+
+The control plane instance should become active in a few minutes and be accessible through its
+floating ip address.
+
+```
+openstack server list
+
+# output
++--------------------------------------+------------------------+--------+------------------------------------------------------------+--------------+-----------+
+| ID                                   | Name                   | Status | Networks                                                   | Image        | Flavor    |
++--------------------------------------+------------------------+--------+------------------------------------------------------------+--------------+-----------+
+| a51e5053-59bd-4da3-98c9-479858a84b59 | c1-control-plane-9qtfm | ACTIVE | k8s-clusterapi-cluster-default-c1=10.6.0.123, 172.24.4.123 | ubuntu-noble | m1.medium |
++--------------------------------------+------------------------+--------+------------------------------------------------------------+--------------+-----------+
+```
+
+We'll create and assign a new security group to allow SSH traffic:
+
+```
+cpNode=$(kubectl get machine -o "jsonpath={.items[0].status.nodeRef.name}"  | grep control-plane)
+openstack security group create ssh 
+openstack security group rule create ssh --protocol tcp --dst-port 22
+openstack server add security group $cpNode ssh
+```
+
+Obtain the floating IP address and ssh into the control plane node:
+
+```
+cpFip=$(openstack server show  $cpNode -f json | jq '.addresses[][1]' -r)
+ssh ubuntu@$cpFip
+```
+
+Verify the node status:
+
+```
+sudo k8s kubectl get nodes
+NAME                     STATUS   ROLES                  AGE   VERSION
+c1-control-plane-9qtfm   Ready    control-plane,worker   68m   v1.32.2
+```
+
+<!-- LINKS -->
+[clouds.yaml]: https://docs.openstack.org/python-openstackclient/2024.2/configuration/index.html#clouds-yaml
+[CAPO provider]: https://github.com/kubernetes-sigs/cluster-api-provider-openstack
+[Openstack Cloud Controller Manager]: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+[template-varaibles.rc]: ./template-variables.rc
+[template-varaibles-devstack.rc]: ./template-variables-devstack.rc
+[Devstack]: https://github.com/openstack/devstack
+[Kind]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation
+[clusterctl]: https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl

--- a/templates/openstack/cluster-template.yaml
+++ b/templates/openstack/cluster-template.yaml
@@ -1,0 +1,434 @@
+apiVersion: v1
+data:
+  cacert: ${OPENSTACK_CLOUD_CACERT_B64}
+  clouds.yaml: ${OPENSTACK_CLOUD_YAML_B64}
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: ${CLUSTER_NAME}-cloud-config
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: CK8sControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  spec:
+    controlPlane:
+      cloudProvider: external
+    extraKubeletArgs:
+      --provider-id: openstack:///'{{ instance_id }}'
+  machineTemplate:
+    infrastructureTemplate:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: OpenStackMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      failureDomain: ${OPENSTACK_FAILURE_DOMAIN}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: CK8sConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: OpenStackMachineTemplate
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: CK8sConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      controlPlane:
+        cloudProvider: external
+      extraKubeletArgs:
+        --provider-id: openstack:///'{{ instance_id }}'
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 10.1.0.0/16
+    services:
+      cidrBlocks:
+        - 10.152.183.0/24
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    kind: CK8sControlPlane
+    name: ${CLUSTER_NAME}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  # TODO: use a variable.
+  apiServerLoadBalancer:
+    enabled: ${OPENSTACK_ENABLE_APISERVER_LOADBALANCER}
+  externalNetwork:
+    id: ${OPENSTACK_EXTERNAL_NETWORK_ID}
+  identityRef:
+    cloudName: ${OPENSTACK_CLOUD}
+    name: ${CLUSTER_NAME}-cloud-config
+  managedSecurityGroups:
+    allNodesSecurityGroupRules:
+    - description: Created by cluster-api-provider-openstack - BGP (calico)
+      direction: ingress
+      etherType: IPv4
+      name: BGP (Calico)
+      portRangeMax: 179
+      portRangeMin: 179
+      protocol: tcp
+      remoteManagedGroups:
+      - controlplane
+      - worker
+    - description: Created by cluster-api-provider-openstack - IP-in-IP (calico)
+      direction: ingress
+      etherType: IPv4
+      name: IP-in-IP (calico)
+      protocol: "4"
+      remoteManagedGroups:
+      - controlplane
+      - worker
+  managedSubnets:
+  - cidr: 10.6.0.0/24
+    dnsNameservers:
+    - ${OPENSTACK_DNS_NAMESERVERS}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      flavor: ${OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
+      sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      flavor: ${OPENSTACK_NODE_MACHINE_FLAVOR}
+      image:
+        filter:
+          name: ${OPENSTACK_IMAGE_NAME}
+      sshKeyName: ${OPENSTACK_SSH_KEY_NAME}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ccm-roles
+data:
+  data: |
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:cloud-controller-manager
+    rules:
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - '*'
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - services/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - serviceaccounts
+      verbs:
+      - create
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - serviceaccounts/token
+      verbs:
+      - create
+    - apiGroups:
+      - ""
+      resources:
+      - persistentvolumes
+      verbs:
+      - '*'
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - list
+      - get
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: system:cloud-node-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - '*'
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/status
+      verbs:
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+      - update
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ccm-role-bindings
+data:
+  data: |
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: system:cloud-node-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:cloud-node-controller
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-node-controller
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: system:cloud-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:cloud-controller-manager
+    subjects:
+    - kind: ServiceAccount
+      name: cloud-controller-manager
+      namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ccm-ds
+data:
+  data: |
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: cloud-controller-manager
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: openstack-cloud-controller-manager
+      namespace: kube-system
+      labels:
+        k8s-app: openstack-cloud-controller-manager
+    spec:
+      selector:
+        matchLabels:
+          k8s-app: openstack-cloud-controller-manager
+      updateStrategy:
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            k8s-app: openstack-cloud-controller-manager
+        spec:
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          securityContext:
+            runAsUser: 1001
+          tolerations:
+          - key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+          serviceAccountName: cloud-controller-manager
+          containers:
+            - name: openstack-cloud-controller-manager
+              image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.32.0
+              args:
+                - /bin/openstack-cloud-controller-manager
+                - --v=1
+                - --cluster-name=$(CLUSTER_NAME)
+                - --cloud-config=$(CLOUD_CONFIG)
+                - --cloud-provider=openstack
+                - --use-service-account-credentials=false
+                - --bind-address=127.0.0.1
+              volumeMounts:
+                - mountPath: /etc/kubernetes/pki
+                  name: k8s-certs
+                  readOnly: true
+                - mountPath: /etc/ssl/certs
+                  name: ca-certs
+                  readOnly: true
+                - mountPath: /etc/config
+                  name: cloud-config-volume
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 200m
+              env:
+                - name: CLOUD_CONFIG
+                  value: /etc/config/cloud.conf
+                - name: CLUSTER_NAME
+                  value: kubernetes
+          dnsPolicy: ClusterFirst
+          hostNetwork: true
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/pki
+              type: DirectoryOrCreate
+            name: k8s-certs
+          - hostPath:
+              path: /etc/ssl/certs
+              type: DirectoryOrCreate
+            name: ca-certs
+          - name: cloud-config-volume
+            secret:
+              secretName: cloud-config
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ccm-config-secret
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  data: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: cloud-config
+      namespace: kube-system
+    data:
+      cloud.conf: ${OPENSTACK_CLOUD_CONFIG_B64}
+    type: Opaque
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}-crs-0
+spec:
+  clusterSelector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+  resources:
+    - kind: Secret
+      name: ccm-config-secret
+    - kind: ConfigMap
+      name: ccm-roles
+    - kind: ConfigMap
+      name: ccm-role-bindings
+    - kind: ConfigMap
+      name: ccm-ds

--- a/templates/openstack/template-variables-devstack.rc
+++ b/templates/openstack/template-variables-devstack.rc
@@ -1,0 +1,77 @@
+# Prerequisites:
+# * ORC (Openstack Resource Controller):
+#   * kubectl apply -f https://github.com/k-orc/openstack-resource-controller/releases/latest/download/install.yaml
+# * Openstack and Canonical K8s providers: 
+#  * clusterctl init -i openstack -b canonical-kubernetes -c canonical-kubernetes
+# * sourced devstack/openrc
+
+KEY_NAME=${KEY_NAME:"k8s-key"}
+IMAGE_NAME=${IMAGE_NAME:-"ubuntu-noble"}
+IMAGE_URL=${IMAGE_URL:-"https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"}
+SSH_PUBKEY=${SSH_PUBKEY:-"~/.ssh/id_rsa.pub"}
+
+if ! openstack keypair show $KEY_NAME; then
+    openstack keypair create $KEY_NAME --public-key $SSH_PUBKEY
+fi
+
+if ! openstack image show $IMAGE_NAME; then
+    download_path=/tmp/capi-image.img
+    wget $IMAGE_URL -O $download_path
+    openstack image create $IMAGE_NAME \
+        --file $download_path \
+        --container-format=bare --disk-format=qcow2 \
+        --property hw_firmware_type=uefi
+    rm $download_path
+fi
+
+if openstack endpoint list | grep load-balancer; then
+    export OPENSTACK_ENABLE_APISERVER_LOADBALANCER="true"
+else
+    export OPENSTACK_ENABLE_APISERVER_LOADBALANCER="false"
+fi
+
+# $OS_* env variables are provided by the devstack openrc file.
+# https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+cat <<EOF > /tmp/ccm_cloud_config
+[Global]
+auth-url = $OS_AUTH_URL
+os-endpoint-type = "public"
+password = $OS_PASSWORD
+region = $OS_REGION_NAME
+tenant-domain-id = $OS_PROJECT_DOMAIN_ID
+tenant-name = $OS_PROJECT_NAME
+user-domain-id = $OS_USER_DOMAIN_ID
+username = $OS_USERNAME
+
+[Networking]
+
+[LoadBalancer]
+enabled = $OPENSTACK_ENABLE_APISERVER_LOADBALANCER
+EOF
+export OPENSTACK_CLOUD_CONFIG_B64=$(cat /tmp/ccm_cloud_config | base64 -w0)
+
+export KUBERNETES_VERSION="v1.32.2"
+
+export CONTROL_PLANE_MACHINE_COUNT=1
+export WORKER_MACHINE_COUNT=1
+
+# Source:
+# * https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/docs/book/src/clusteropenstack/configuration.md
+# * https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/cb7f90559b99fd8c64d742cdf07c3f7bd4582ce7/test/e2e/data/e2e_conf.yaml#L152-L193
+
+# For this test, we'll use the devstack clouds.yaml and admin credentials.
+export OPENSTACK_CLOUD_YAML_B64=$(cat /etc/openstack/clouds.yaml | base64 -w0)
+export OPENSTACK_CLOUD="devstack-admin"
+
+export OPENSTACK_SSH_KEY_NAME=$KEY_NAME
+export OPENSTACK_IMAGE_NAME=$IMAGE_NAME
+# We'll use the default public network created by Devstack.
+export OPENSTACK_EXTERNAL_NETWORK_ID=$(openstack network list | grep public | cut -d " " -f 2)
+
+export OPENSTACK_CLOUD_CACERT_B64="Cg=="
+
+export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR="ds4G"
+export OPENSTACK_NODE_MACHINE_FLAVOR="ds4G"
+export OPENSTACK_DNS_NAMESERVERS="8.8.8.8"
+# The OpenStack availability zone.
+export OPENSTACK_FAILURE_DOMAIN="nova"

--- a/templates/openstack/template-variables.rc
+++ b/templates/openstack/template-variables.rc
@@ -1,0 +1,40 @@
+# K8s Version of the cluster, e.g. "v1.32.2"
+export KUBERNETES_VERSION="v1.32.2"
+
+export CONTROL_PLANE_MACHINE_COUNT=1
+export WORKER_MACHINE_COUNT=1
+
+# Source:
+# * https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/docs/book/src/clusteropenstack/configuration.md
+# * https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/cb7f90559b99fd8c64d742cdf07c3f7bd4582ce7/test/e2e/data/e2e_conf.yaml#L152-L193
+# * https://github.com/kubernetes-sigs/cluster-api-provider-openstack/tree/main/templates
+
+# The keypair used to access Openstack instances.
+export OPENSTACK_SSH_KEY_NAME=
+# The Openstack image used when deploying Canonical K8s nodes.
+export OPENSTACK_IMAGE_NAME=
+# The external Openstack network id.
+export OPENSTACK_EXTERNAL_NETWORK_ID=
+# The name of the cloud from the clouds.yaml file.
+export OPENSTACK_CLOUD=
+# Base64 encoded clouds.yaml file, containing Openstack credentials.
+# https://docs.openstack.org/python-openstackclient/2024.2/configuration/index.html#clouds-yaml
+export OPENSTACK_CLOUD_YAML_B64=
+
+# The Openstack Cloud Contrller Manager configuration, base64 encoded.
+# https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+export OPENSTACK_CLOUD_CONFIG_B64=
+
+# Optional: base64 encoded CA certificate used when contacting Openstack services.
+export OPENSTACK_CLOUD_CACERT_B64="Cg=="
+export OPENSTACK_ENABLE_APISERVER_LOADBALANCER="false"
+
+# The OpenStack Nova availability zone.
+export OPENSTACK_FAILURE_DOMAIN=
+
+# The Opentack flavor used to deploy control plane nodes.
+export OPENSTACK_CONTROL_PLANE_MACHINE_FLAVOR="m1.medium"
+# The Opentack flavor used to deploy worker nodes.
+export OPENSTACK_NODE_MACHINE_FLAVOR="m1.medium"
+# The list of DNS nameservers to use for Openstack instances.
+export OPENSTACK_DNS_NAMESERVERS="8.8.8.8"


### PR DESCRIPTION
We're adding CAPI templates that can be used to deploy Canonical K8s on OpenStack.

See the readme for more details.