### PR TITLE
Returns error when failing to remove machine from microcluster

### DIFF
--- a/controlplane/controllers/remediation.go
+++ b/controlplane/controllers/remediation.go
@@ -177,8 +177,13 @@ func (r *CK8sControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.Cont
 		return ctrl.Result{}, fmt.Errorf("failed to create client to workload cluster: %w", err)
 	}
 
-	if err := workloadCluster.RemoveMachineFromCluster(ctx, machineToBeRemediated); err != nil {
-		log.Error(err, "failed to remove machine from microcluster")
+	if machineToBeRemediated.Status.NodeRef != nil {
+		// TODO: If the node is not part of the microcluster, this may still return an error. We should catch that case,
+		// and proceed with the machine removal.
+		if err := workloadCluster.RemoveMachineFromCluster(ctx, machineToBeRemediated); err != nil {
+			log.Error(err, "failed to remove machine from microcluster")
+			return ctrl.Result{}, fmt.Errorf("failed to remove machine from microcluster: %w", err)
+		}
 	}
 
 	// Delete the machine

--- a/controlplane/controllers/scale.go
+++ b/controlplane/controllers/scale.go
@@ -127,8 +127,13 @@ func (r *CK8sControlPlaneReconciler) scaleDownControlPlane(
 		return ctrl.Result{}, fmt.Errorf("failed to create client to workload cluster: %w", err)
 	}
 
-	if err := workloadCluster.RemoveMachineFromCluster(ctx, machineToDelete); err != nil {
-		logger.Error(err, "failed to remove machine from microcluster")
+	if machineToDelete.Status.NodeRef != nil {
+		// TODO: If the node is not part of the microcluster, this may still return an error. We should catch that case,
+		// and proceed with the machine removal.
+		if err := workloadCluster.RemoveMachineFromCluster(ctx, machineToDelete); err != nil {
+			logger.Error(err, "failed to remove machine from microcluster")
+			return ctrl.Result{}, fmt.Errorf("failed to remove machine from microcluster: %w", err)
+		}
 	}
 
 	logger = logger.WithValues("machine", machineToDelete)


### PR DESCRIPTION
If the microcluster request failed, we shouldn't proceed to remove the node's Machine, the node may still be registered as a node in the microcluster, leading it to becoming unhealthy and unstable.