### PR TITLE
fix: Add bot ssh key to pre-release automation

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -24,11 +24,9 @@ jobs:
   handle-prereleases:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
       - uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.BOT_SSH_KEY }} 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'


### PR DESCRIPTION
Also removing left over harden runner step (we removed this external workflow a while ago).