### PR TITLE
CI: add jirasync for gh issues

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,34 @@
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "KU"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done
+
+  # (Optional) Jira project components that should be attached to the created issue
+  # Component names are case-sensitive
+  components:
+    - K8s snap
+
+  # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
+  # If not specified, all issues will be synchronized
+  #  labels: []
+
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  add_gh_comment: false
+
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  sync_description: true
+
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  sync_comments: true
+
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: "KU-25"
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story


### PR DESCRIPTION
## Jirasync

This PR adds a jirasync automation for our github issues.

Note: Component field says k8s snap- we currently don't really filter by component. 
We could add a "CAPI k8s snap component" if we really want to but I don't see a need to.