### PR TITLE
fix: use the correct proxy file locations

### DIFF
--- a/pkg/cloudinit/scripts/configure-proxy.sh
+++ b/pkg/cloudinit/scripts/configure-proxy.sh
@@ -3,10 +3,10 @@
 # Assumptions:
 #   - runs before install k8s
 
-HTTP_PROXY_FILE="/tmp/capi/etc/http-proxy"
-HTTPS_PROXY_FILE="/tmp/capi/etc/https-proxy"
-NO_PROXY_FILE="/tmp/capi/etc/no-proxy"
-ENVIRONMENT_FILE="/tmp/etc/environment"
+HTTP_PROXY_FILE="/capi/etc/http-proxy"
+HTTPS_PROXY_FILE="/capi/etc/https-proxy"
+NO_PROXY_FILE="/capi/etc/no-proxy"
+ENVIRONMENT_FILE="/etc/environment"
 
 if [ -f ${HTTP_PROXY_FILE} ]; then
   HTTP_PROXY=$(cat ${HTTP_PROXY_FILE})


### PR DESCRIPTION
The configure-proxy.sh script adds a superfluous "/tmp/" prefix to the proxy file paths:

```
HTTP_PROXY_FILE="/tmp/capi/etc/http-proxy"
HTTPS_PROXY_FILE="/tmp/capi/etc/https-proxy"
NO_PROXY_FILE="/tmp/capi/etc/no-proxy"
ENVIRONMENT_FILE="/tmp/etc/environment"
```

For this reason, the proxy settings are not applied correctly.

We'll fix the issue by simply removing the "/tmp/" prefix.

Fixes: https://github.com/canonical/cluster-api-k8s/issues/125