### PR TITLE
CI: fix unit test jobs

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     # At 00:00 every day
     - cron: '0 0 * * *'
+  pull_request:
+    paths:
+      - .github/workflows/cron-jobs.yaml
 
 permissions:
   contents: read
@@ -15,11 +18,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
-
       - name: Checking out repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/lint_and_unit_tests.yaml
+++ b/.github/workflows/lint_and_unit_tests.yaml
@@ -15,11 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
-
       - name: Check out code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
The unit test jobs are now failing, being unable to stop processes
as part of the test suite cleanup.

This was caused by recent changes in the `step-security/harden-runner@v2`
action.

To unblock the CI, we'll have to drop the `harden-runner` action.
Note that k8s-snap doesn't use it either.

While at it, we'll trigger the TICS cron job whenever the job
definition changes.

```
STEP: tearing down the test environment
Failure [0.001 seconds]
[AfterSuite] AfterSuite
/home/runner/work/cluster-api-k8s/cluster-api-k8s/bootstrap/controllers/suite_test.go:71

  Unexpected error:
      <errors.aggregate | len:2, cap:2>:
      [unable to signal for process /home/runner/work/cluster-api-k8s/cluster-api-k8s/bin/k8s/1.32.0->      [
          <*fmt.wrapError | 0xc00005ede0>{
              msg: "unable to signal for process /home/runner/work/cluster-api-k8s/cluster-api-k8s/bi>              err: <syscall.Errno>0x1,
          },
          <*fmt.wrapError | 0xc00005ee40>{
              msg: "unable to signal for process /home/runner/work/cluster-api-k8s/cluster-api-k8s/bi>              err: <syscall.Errno>0x1,
          },
      ]
```