### PR TITLE
chore: (AWS) Change LB type to NLB following the deprecation of ELB

### DIFF
--- a/templates/aws/cluster-template.yaml
+++ b/templates/aws/cluster-template.yaml
@@ -31,7 +31,8 @@ spec:
   bastion:
     enabled: ${AWS_CREATE_BASTION}
   controlPlaneLoadBalancer:
-    healthCheckProtocol: TCP
+    loadBalancerType: nlb
+    healthCheckProtocol: HTTPS
   network:
     cni:
       cniIngressRules:

--- a/templates/aws/template-variables.rc
+++ b/templates/aws/template-variables.rc
@@ -11,8 +11,8 @@ export AWS_CREATE_BASTION="true"
 export AWS_PUBLIC_IP="true"
 export AWS_CONTROL_PLANE_INSTANCE_TYPE="t3.large"
 export AWS_NODE_INSTANCE_TYPE="t3.large"
-export AWS_CONTROL_PLANE_ROOT_VOLUME_SIZE=16
-export AWS_NODE_ROOT_VOLUME_SIZE=16
+export AWS_CONTROL_PLANE_ROOT_VOLUME_SIZE=40
+export AWS_NODE_ROOT_VOLUME_SIZE=40
 export AWS_SSH_KEY_NAME="default"
 # List upstream AMIs with clusterawsadm ami list --owner-id 819546954734
 export AWS_AMI_ID="ami-027b534ab5d0b4886"

--- a/test/e2e/data/infrastructure-aws/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-aws/cluster-template.yaml
@@ -31,7 +31,8 @@ spec:
   bastion:
     enabled: ${AWS_CREATE_BASTION}
   controlPlaneLoadBalancer:
-    healthCheckProtocol: TCP
+    loadBalancerType: nlb
+    healthCheckProtocol: HTTPS
   network:
     cni:
       cniIngressRules:


### PR DESCRIPTION
### Overview
This PR changes the LB type to `nlb` following the deprecation of the classic `elb`.
Upstream PRs:
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5338
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5345

This also updates the default root disk size in the AWS template to 40GB according to our [docs](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/tutorial/getting-started/). 

Fixes: https://github.com/canonical/cluster-api-k8s/issues/141
Fixes: https://github.com/canonical/cluster-api-k8s/issues/143