### PR TITLE
feat: add managed etcd datastore option

### DIFF
--- a/bootstrap/api/v1beta2/ck8sconfig_types.go
+++ b/bootstrap/api/v1beta2/ck8sconfig_types.go
@@ -136,7 +136,7 @@ type CK8sConfigSpec struct {
 // IsEtcdManaged returns true if the control plane is using k8s-dqlite.
 func (c *CK8sConfigSpec) IsEtcdManaged() bool {
 	switch c.ControlPlaneConfig.DatastoreType {
-	case "", "k8s-dqlite":
+	case "", "etcd", "k8s-dqlite":
 		return true
 	}
 	return false
@@ -167,6 +167,14 @@ type CK8sControlPlaneConfig struct {
 	// K8sDqlitePort is the port to use for k8s-dqlite. If unset, 2379 (etcd) will be used.
 	// +optional
 	K8sDqlitePort int `json:"k8sDqlitePort,omitempty"`
+
+	// EtcdPort is the port to use for etcd. If unset, 2379 will be used.
+	// +optional
+	EtcdPort int `json:"etcdPort,omitempty"`
+
+	// EtcdPeerPort is the port to use for etcd peer communication. If unset, 2381 will be used.
+	// +optional
+	EtcdPeerPort int `json:"etcdPeerPort,omitempty"`
 
 	// MicroclusterAddress is the address (or CIDR) to use for microcluster. If unset, the default node interface is chosen.
 	MicroclusterAddress string `json:"microclusterAddress,omitempty"`

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigs.yaml
@@ -134,6 +134,14 @@ spec:
                     description: DatastoreType is the type of datastore to use for
                       the control plane.
                     type: string
+                  etcdPeerPort:
+                    description: EtcdPeerPort is the port to use for etcd peer communication.
+                      If unset, 2381 will be used.
+                    type: integer
+                  etcdPort:
+                    description: EtcdPort is the port to use for etcd. If unset, 2379
+                      will be used.
+                    type: integer
                   extraKubeAPIServerArgs:
                     additionalProperties:
                       type: string

--- a/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
+++ b/bootstrap/config/crd/bases/bootstrap.cluster.x-k8s.io_ck8sconfigtemplates.yaml
@@ -142,6 +142,14 @@ spec:
                             description: DatastoreType is the type of datastore to
                               use for the control plane.
                             type: string
+                          etcdPeerPort:
+                            description: EtcdPeerPort is the port to use for etcd
+                              peer communication. If unset, 2381 will be used.
+                            type: integer
+                          etcdPort:
+                            description: EtcdPort is the port to use for etcd. If
+                              unset, 2379 will be used.
+                            type: integer
                           extraKubeAPIServerArgs:
                             additionalProperties:
                               type: string

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanes.yaml
@@ -353,6 +353,14 @@ spec:
                         description: DatastoreType is the type of datastore to use
                           for the control plane.
                         type: string
+                      etcdPeerPort:
+                        description: EtcdPeerPort is the port to use for etcd peer
+                          communication. If unset, 2381 will be used.
+                        type: integer
+                      etcdPort:
+                        description: EtcdPort is the port to use for etcd. If unset,
+                          2379 will be used.
+                        type: integer
                       extraKubeAPIServerArgs:
                         additionalProperties:
                           type: string

--- a/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
+++ b/controlplane/config/crd/bases/controlplane.cluster.x-k8s.io_ck8scontrolplanetemplates.yaml
@@ -329,6 +329,14 @@ spec:
                                 description: DatastoreType is the type of datastore
                                   to use for the control plane.
                                 type: string
+                              etcdPeerPort:
+                                description: EtcdPeerPort is the port to use for etcd
+                                  peer communication. If unset, 2381 will be used.
+                                type: integer
+                              etcdPort:
+                                description: EtcdPort is the port to use for etcd.
+                                  If unset, 2379 will be used.
+                                type: integer
                               extraKubeAPIServerArgs:
                                 additionalProperties:
                                   type: string

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/canonical/cluster-api-k8s
 go 1.24.0
 
 require (
-	github.com/canonical/k8s-snap-api v1.0.25
+	github.com/canonical/k8s-snap-api v1.1.0
 	github.com/go-logr/logr v1.4.2
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-github.com/canonical/k8s-snap-api v1.0.25 h1:xexgkZRHHEJouqY2tC6cqp7Tzfj3Nw0vFKRdT+VGDJA=
-github.com/canonical/k8s-snap-api v1.0.25/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.1.0 h1:RME41bv1t8TY4IIEoVs8JOqJO5C9UW+CC/TEPvWKXnA=
+github.com/canonical/k8s-snap-api v1.1.0/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/ck8s/config_init.go
+++ b/pkg/ck8s/config_init.go
@@ -70,7 +70,23 @@ func GenerateInitControlPlaneConfig(cfg InitControlPlaneConfig) (apiv1.Bootstrap
 	}
 
 	switch cfg.DatastoreType {
-	case "", "k8s-dqlite":
+	case "", "etcd":
+		out.DatastoreType = ptr.To("etcd")
+
+		etcdPort := cfg.ControlPlaneConfig.EtcdPort
+		if etcdPort == 0 {
+			etcdPort = 2379
+		}
+		out.EtcdPort = ptr.To(etcdPort)
+
+		etcdPeerPort := cfg.ControlPlaneConfig.EtcdPeerPort
+		if etcdPeerPort == 0 {
+			// TODO(berkayoz): This should be 2080 however it clashes with our workaround
+			// for exposing microcluster through 2080 via k8sd-proxy
+			etcdPeerPort = 2381
+		}
+		out.EtcdPeerPort = ptr.To(etcdPeerPort)
+	case "k8s-dqlite":
 		// Set default datastore type to k8s-dqlite
 		out.DatastoreType = ptr.To("k8s-dqlite")
 

--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -20,12 +20,12 @@
 ## See https://kind.sigs.k8s.io/docs/design/node-image/
 ##
 ## !!!IMPORTANT!!! Keep this up to date with the minor version of k8s-snap.
-ARG BASE=kindest/node:v1.32.2
+ARG BASE=kindest/node:v1.33.2
 
 ## NOTE(neoaggelos): Builder uses the ubuntu:20.04 as base image
 ##
 ## !!!IMPORTANT!!! Keep the base image up to date with the base image from "snapcraft.yaml:base".
-ARG BUILD_BASE=ubuntu:20.04
+ARG BUILD_BASE=ubuntu:22.04
 
 ####################################################################################################
 ## IMAGE(builder): Used as base image for building k8s-snap components


### PR DESCRIPTION
Should be rebased and merged after #171 and #172