### PR TITLE
chore: use the default classic/stable channel

### DIFF
--- a/templates/aws/cluster-template.yaml
+++ b/templates/aws/cluster-template.yaml
@@ -52,8 +52,6 @@ spec:
       name: ${CLUSTER_NAME}-control-plane
   spec:
     nodeName: "{{ ds.meta_data.local_hostname }}"
-    # note(ben): This is only required as long as k8s does not have a stable release.
-    channel: "1.32-classic/edge"
     controlPlane:
       cloudProvider: external
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -123,8 +121,6 @@ spec:
   template:
     spec:
       nodeName: "{{ ds.meta_data.local_hostname }}"
-      # note(ben): This is only required as long as k8s does not have a stable release.
-      channel: "1.32-classic/edge"
 ---
 apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet


### PR DESCRIPTION
Addresses https://github.com/canonical/cluster-api-k8s/issues/149

When no `channel` or revision is defined, the `classic/stable` [is set](https://github.com/canonical/cluster-api-k8s/blob/25065dd738b795bfe0addc83ea088988210c760c/pkg/cloudinit/common.go#L78-L84) as the default value.