### PR TITLE
ci: add tmate session to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -116,12 +116,14 @@ jobs:
           # Prevents https://cluster-api.sigs.k8s.io/user/troubleshooting#cluster-api-with-docker----too-many-open-files
           sudo sysctl fs.inotify.max_user_watches=1048576
           sudo sysctl fs.inotify.max_user_instances=8192
-      - name: Setup tmate session
-        uses: canonical/action-tmate@main
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
       - name: Run e2e tests
         run: |
           sudo GINKGO_FOCUS="${{ matrix.ginkgo_focus }}" SKIP_RESOURCE_CLEANUP=true make test-e2e
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
+        with:
+          detached: true
       - name: Change artifact permissions
         if: always()
         run: |


### PR DESCRIPTION
- Adds `workflow_dispatch` event to the e2e tests to being able to run the tests without the need to create a PR. 
- Adds `tmate` session option to properly investigate the test environment. 