### PR TITLE
chore: bump go to 1.24 and golanci-lint to v2.3.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,15 +28,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Install requirements
         run: |
           sudo apt update
-          sudo snap install go --classic --channel=1.23/stable
           sudo apt install make
           sudo apt install docker-buildx
           sudo snap install kubectl --classic --channel=1.32/stable
       - name: Build provider images
-        run: sudo make docker-build-e2e
+        run: sudo env "PATH=$PATH" make docker-build-e2e
       - name: Build k8s-snap images
         working-directory: hack/
         run: |
@@ -87,10 +90,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Check out repo
         uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Install requirements
         run: |
           sudo apt update
-          sudo snap install go --classic --channel=1.23/stable
           sudo apt install make
           sudo apt install docker-buildx
           sudo snap install kubectl --classic --channel=1.32/stable
@@ -123,7 +129,7 @@ jobs:
           detached: true
       - name: Run e2e tests
         run: |
-          sudo GINKGO_FOCUS="${{ matrix.ginkgo_focus }}" SKIP_RESOURCE_CLEANUP=true make test-e2e
+          sudo env "PATH=$PATH" GINKGO_FOCUS="${{ matrix.ginkgo_focus }}" SKIP_RESOURCE_CLEANUP=true make test-e2e
       - name: Change artifact permissions
         if: always()
         run: |

--- a/.github/workflows/lint_and_unit_tests.yaml
+++ b/.github/workflows/lint_and_unit_tests.yaml
@@ -24,9 +24,9 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.61
+          version: v2.3.0
 
       - name: Unit Tests
         run: make test-unit

--- a/.github/workflows/lint_and_unit_tests.yaml
+++ b/.github/workflows/lint_and_unit_tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/sync-images.yaml
+++ b/.github/workflows/sync-images.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Sync images
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,9 @@ linters:
             - github.com/google/uuid
             - github.com/pkg/errors
             - sigs.k8s.io/kind/pkg/errors
+            - golang.org/x/sync/errgroup
+            - gopkg.in/yaml.v3
+            - google.golang.org/protobuf/proto
     godot:
       #   declarations - for top level declaration comments (default);
       #   toplevel     - for top level comments;

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,5 @@
 run:
   timeout: 5m
-  go: '1.23'
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,157 +1,167 @@
+version: "2"
 run:
   timeout: 5m
-issues:
-  max-same-issues: 0
-  max-issues-per-linter: 0
-  exclude-files:
-    - ".*zz_generated.*\\.go"
-    - "contrib/.*"
-  exclude-rules:
-    - path: "test/e2e/*"
-      linters:
-        - gosec
-      text: "G106:"
-    - linters:
-        - revive
-      text: "dot-imports"
-      path: ".*test.*"
-    - linters:
-        - stylecheck
-      text: "ST1001"
-      path: ".*test.*"
-
 linters:
-  fast: true
-  disable-all: true
+  default: none
   enable:
-  - asciicheck
-  - bodyclose
-  - depguard
-  - dogsled
-  - errcheck
-  - exportloopref
-  - gci
-  - goconst
-  - gocritic
-  - gocyclo
-  - godot
-  - gofmt
-  - goimports
-  - goprintffuncname
-  - gosec
-  - gosimple
-  - govet
-  - importas
-  - ineffassign
-  - misspell
-  - nakedret
-  - nilerr
-  - noctx
-  - nolintlint
-  - prealloc
-  - predeclared
-  - revive
-  - rowserrcheck
-  - staticcheck
-  - stylecheck
-  - thelper
-  - typecheck
-  - unconvert
-  - unparam
-  - unused
-  - whitespace
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        allow:
-          - $gostd
-          - github.com/go-logr/logr
-          - github.com/coredns/corefile-migration/migration
-          - github.com/pkg/errors
-
-          - k8s.io/api
-          - k8s.io/apimachinery/pkg
-          - k8s.io/apiserver
-          - k8s.io/kubernetes
-          - k8s.io/client-go
-          - k8s.io/klog/v2
-          - k8s.io/utils/ptr
-
-          - github.com/onsi/ginkgo
-          - github.com/onsi/gomega
-
-          - sigs.k8s.io/yaml
-          - sigs.k8s.io/controller-runtime
-          - sigs.k8s.io/cluster-api
-
-          - github.com/canonical/cluster-api-k8s
-          - github.com/canonical/k8s-snap-api
-
-          - github.com/google/uuid
-          - github.com/pkg/errors
-          - sigs.k8s.io/kind/pkg/errors
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/canonical/cluster-api-k8s)
-  gomoddirectives:
-    # List of allowed `replace` directives.
-    # Default: []
-    replace-allow-list:
-      - sigs.k8s.io/cluster-api
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/canonical/cluster-api-k8s
-  godot:
-    #   declarations - for top level declaration comments (default);
-    #   toplevel     - for top level comments;
-    #   all          - for all comments.
-    scope: toplevel
-    exclude:
-    - '^ \+.*'
-    - '^ ANCHOR.*'
-  gosec:
-    excludes:
-    - G307 # Deferring unsafe method "Close" on type "\*os.File"
-    - G108 # Profiling endpoint is automatically exposed on /debug/pprof
-    - G115 # Integer overflow conversion int -> int32, Kubernetes replicas field is type int32
-  importas:
-    # Do not allow unaliased imports of aliased packages.
-    # Default: false
-    no-unaliased: true
-    alias:
-      # Kubernetes
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
-      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-        alias: apiextensionsv1
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
-      - pkg: k8s.io/apimachinery/pkg/util/errors
-        alias: kerrors
-      # Controller Runtime
-      - pkg: sigs.k8s.io/controller-runtime
-        alias: ctrl
-  nolintlint:
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
-  revive:
-    rules:
-      - name: exported
-        arguments:
-          - disableStutteringCheck
-      - name: unused-parameter
-        disabled: true
-  tagliatelle:
-    case:
+    - asciicheck
+    - bodyclose
+    - depguard
+    - dogsled
+    - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - goprintffuncname
+    - gosec
+    - govet
+    - importas
+    - ineffassign
+    - misspell
+    - nakedret
+    - nilerr
+    - noctx
+    - nolintlint
+    - prealloc
+    - predeclared
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - thelper
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+  settings:
+    depguard:
       rules:
-        # Any struct tag type can be used.
-        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`
-        json: goCamel
+        main:
+          allow:
+            - $gostd
+            - github.com/go-logr/logr
+            - github.com/coredns/corefile-migration/migration
+            - github.com/pkg/errors
+            - k8s.io/api
+            - k8s.io/apimachinery/pkg
+            - k8s.io/apiserver
+            - k8s.io/kubernetes
+            - k8s.io/client-go
+            - k8s.io/klog/v2
+            - k8s.io/utils/ptr
+            - github.com/onsi/ginkgo
+            - github.com/onsi/gomega
+            - sigs.k8s.io/yaml
+            - sigs.k8s.io/controller-runtime
+            - sigs.k8s.io/cluster-api
+            - github.com/canonical/cluster-api-k8s
+            - github.com/canonical/k8s-snap-api
+            - github.com/google/uuid
+            - github.com/pkg/errors
+            - sigs.k8s.io/kind/pkg/errors
+    godot:
+      #   declarations - for top level declaration comments (default);
+      #   toplevel     - for top level comments;
+      #   all          - for all comments.
+      scope: toplevel
+      exclude:
+        - ^ \+.*
+        - ^ ANCHOR.*
+    gomoddirectives:
+      # List of allowed `replace` directives.
+      # Default: []
+      replace-allow-list:
+        - sigs.k8s.io/cluster-api
+    gosec:
+      excludes:
+        - G307 # Deferring unsafe method "Close" on type "\*os.File"
+        - G108 # Profiling endpoint is automatically exposed on /debug/pprof
+        - G115 # Integer overflow conversion int -> int32, Kubernetes replicas field is type int32
+    importas:
+      # Kubernetes
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: kerrors
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+      # Do not allow unaliased imports of aliased packages.
+      # Default: false
+      no-unaliased: true
+    nolintlint:
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+        - name: unused-parameter
+          disabled: true
+    tagliatelle:
+      case:
+        rules:
+          # Any struct tag type can be used.
+          # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`
+          json: goCamel
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: test/e2e/*
+        text: 'G106:'
+      - linters:
+          - revive
+        path: .*test.*
+        text: dot-imports
+      - linters:
+          - staticcheck
+        path: .*test.*
+        text: ST1001
+    paths:
+      - .*zz_generated.*\.go
+      - contrib/.*
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/canonical/cluster-api-k8s)
+    goimports:
+      # put imports beginning with prefix after 3rd-party packages;
+      # it's a comma-separated list of prefixes
+      local-prefixes:
+        - github.com/canonical/cluster-api-k8s
+  exclusions:
+    generated: lax
+    paths:
+      - .*zz_generated.*\.go
+      - contrib/.*
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ENVSUBST_BIN := envsubst
 ENVSUBST := $(TOOLS_BIN_DIR)/$(ENVSUBST_BIN)
 
 # Bump as necessary/desired to latest that supports our version of go at https://github.com/golangci/golangci-lint/releases
-GOLANGCI_LINT_VER := v1.61.0
+GOLANGCI_LINT_VER := v2.3.0
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
-GO_VERSION ?= 1.23.0
+GO_VERSION ?= $(shell grep '^go ' go.mod | cut -d' ' -f2 | sed 's/\.0$$//')
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
 ARCH ?= $(shell go env GOARCH)

--- a/bootstrap/controllers/certificates_controller.go
+++ b/bootstrap/controllers/certificates_controller.go
@@ -83,7 +83,7 @@ func (r *CertificatesReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	if !m.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !m.DeletionTimestamp.IsZero() {
 		// Machine is being deleted, return early.
 		return ctrl.Result{}, nil
 	}
@@ -103,7 +103,7 @@ func (r *CertificatesReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// clear the status.
 			delete(mAnnotations, bootstrapv1.CertificatesRefreshStatusAnnotation)
 			m.SetAnnotations(mAnnotations)
-			if err := r.Client.Update(ctx, m); err != nil {
+			if err := r.Update(ctx, m); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to clear status annotation: %w", err)
 			}
 			return ctrl.Result{}, nil
@@ -136,7 +136,7 @@ func (r *CertificatesReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// On error, we requeue the request to retry.
 			mAnnotations[bootstrapv1.CertificatesRefreshStatusAnnotation] = bootstrapv1.CertificatesRefreshFailedStatus
 			m.SetAnnotations(mAnnotations)
-			if err := r.Client.Update(ctx, m); err != nil {
+			if err := r.Update(ctx, m); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to clear status annotation after error: %w", err)
 			}
 			return ctrl.Result{}, err
@@ -148,7 +148,7 @@ func (r *CertificatesReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 func (r *CertificatesReconciler) createScope(ctx context.Context, m *clusterv1.Machine, log logr.Logger) (*CertificatesScope, error) {
 	config := &bootstrapv1.CK8sConfig{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: m.Namespace, Name: m.Spec.Bootstrap.ConfigRef.Name}, config); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: m.Namespace, Name: m.Spec.Bootstrap.ConfigRef.Name}, config); err != nil {
 		return nil, fmt.Errorf("failed to get CK8sConfig: %w", err)
 	}
 

--- a/bootstrap/controllers/ck8sconfig_controller.go
+++ b/bootstrap/controllers/ck8sconfig_controller.go
@@ -90,7 +90,7 @@ func (r *CK8sConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Lookup the ck8s config
 	config := &bootstrapv1.CK8sConfig{}
-	if err := r.Client.Get(ctx, req.NamespacedName, config); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, config); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
@@ -551,7 +551,7 @@ func (r *CK8sConfigReconciler) getSnapInstallDataFromSpec(spec bootstrapv1.CK8sC
 func (r *CK8sConfigReconciler) resolveSecretFileContent(ctx context.Context, ns string, source bootstrapv1.FileSource) ([]byte, error) {
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: ns, Name: source.Secret.Name}
-	if err := r.Client.Get(ctx, key, secret); err != nil {
+	if err := r.Get(ctx, key, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("secret not found %s: %w", key, err)
 		}
@@ -568,7 +568,7 @@ func (r *CK8sConfigReconciler) resolveSecretFileContent(ctx context.Context, ns 
 func (r *CK8sConfigReconciler) resolveSecretReference(ctx context.Context, ns string, secretRef bootstrapv1.SecretRef) ([]byte, error) {
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: ns, Name: secretRef.Name}
-	if err := r.Client.Get(ctx, key, secret); err != nil {
+	if err := r.Get(ctx, key, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("secret not found %s: %w", key, err)
 		}
@@ -792,12 +792,12 @@ func (r *CK8sConfigReconciler) storeBootstrapData(ctx context.Context, scope *Sc
 
 	// as secret creation and scope.Config status patch are not atomic operations
 	// it is possible that secret creation happens but the config.Status patches are not applied
-	if err := r.Client.Create(ctx, secret); err != nil {
+	if err := r.Create(ctx, secret); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create bootstrap data secret for CK8sConfig %s/%s: %w", scope.Config.Namespace, scope.Config.Name, err)
 		}
 		r.Log.Info("bootstrap data secret for CK8sConfig already exists, updating", "secret", secret.Name, "CK8sConfig", scope.Config.Name)
-		if err := r.Client.Update(ctx, secret); err != nil {
+		if err := r.Update(ctx, secret); err != nil {
 			return fmt.Errorf("failed to update bootstrap data secret for CK8sConfig %s/%s: %w", scope.Config.Namespace, scope.Config.Name, err)
 		}
 	}

--- a/bootstrap/controllers/upgrade_controller.go
+++ b/bootstrap/controllers/upgrade_controller.go
@@ -71,7 +71,7 @@ func (r *InPlaceUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	log := r.Log.WithValues("namespace", req.Namespace, "machine", req.Name)
 
 	m := &clusterv1.Machine{}
-	if err := r.Client.Get(ctx, req.NamespacedName, m); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, m); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
@@ -152,7 +152,7 @@ func (r *InPlaceUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 func (r *InPlaceUpgradeReconciler) getWorkloadClusterForMachine(ctx context.Context, clusterKey types.NamespacedName, m *clusterv1.Machine) (*ck8s.Workload, error) {
 	// Lookup the ck8s config used by the machine
 	config := &bootstrapv1.CK8sConfig{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: m.Namespace, Name: m.Spec.Bootstrap.ConfigRef.Name}, config); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: m.Namespace, Name: m.Spec.Bootstrap.ConfigRef.Name}, config); err != nil {
 		return nil, err
 	}
 

--- a/controlplane/controllers/machine_controller.go
+++ b/controlplane/controllers/machine_controller.go
@@ -51,7 +51,7 @@ func (r *MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	logger := r.Log.WithValues("namespace", req.Namespace, "machine", req.Name)
 
 	m := &clusterv1.Machine{}
-	if err := r.Client.Get(ctx, req.NamespacedName, m); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, m); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
@@ -67,8 +67,8 @@ func (r *MachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// if machine registered PreTerminate hook, wait for capi asks to resolve PreTerminateDeleteHook
-	if annotations.HasWithPrefix(clusterv1.PreTerminateDeleteHookAnnotationPrefix, m.ObjectMeta.Annotations) &&
-		m.ObjectMeta.Annotations[clusterv1.PreTerminateDeleteHookAnnotationPrefix] == ck8sHookName {
+	if annotations.HasWithPrefix(clusterv1.PreTerminateDeleteHookAnnotationPrefix, m.Annotations) &&
+		m.Annotations[clusterv1.PreTerminateDeleteHookAnnotationPrefix] == ck8sHookName {
 		if !conditions.IsFalse(m, clusterv1.PreTerminateDeleteHookSucceededCondition) {
 			logger.Info("wait for machine drain and detech volume operation complete.")
 			return ctrl.Result{}, nil

--- a/controlplane/controllers/remediation.go
+++ b/controlplane/controllers/remediation.go
@@ -90,7 +90,7 @@ func (r *CK8sControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.Cont
 	machineToBeRemediated := getMachineToBeRemediated(unhealthyMachines)
 
 	// Returns if the machine is in the process of being deleted.
-	if !machineToBeRemediated.ObjectMeta.DeletionTimestamp.IsZero() {
+	if !machineToBeRemediated.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil
 	}
 
@@ -187,7 +187,7 @@ func (r *CK8sControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.Cont
 	}
 
 	// Delete the machine
-	if err := r.Client.Delete(ctx, machineToBeRemediated); err != nil {
+	if err := r.Delete(ctx, machineToBeRemediated); err != nil {
 		conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.RemediationFailedReason, clusterv1.ConditionSeverityError, "%s", err.Error())
 		return ctrl.Result{}, fmt.Errorf("failed to delete unhealthy machine %s: %w", machineToBeRemediated.Name, err)
 	}

--- a/controlplane/controllers/scale.go
+++ b/controlplane/controllers/scale.go
@@ -137,7 +137,7 @@ func (r *CK8sControlPlaneReconciler) scaleDownControlPlane(
 	}
 
 	logger = logger.WithValues("machine", machineToDelete)
-	if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete control plane machine")
 		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "FailedScaleDown",
 			"Failed to delete control plane Machine %s for cluster %s/%s control plane: %v", machineToDelete.Name, cluster.Namespace, cluster.Name, err)
@@ -295,7 +295,7 @@ func (r *CK8sControlPlaneReconciler) cleanupFromGeneration(ctx context.Context, 
 			config.SetNamespace(ref.Namespace)
 			config.SetName(ref.Name)
 
-			if err := r.Client.Delete(ctx, config); err != nil && !apierrors.IsNotFound(err) {
+			if err := r.Delete(ctx, config); err != nil && !apierrors.IsNotFound(err) {
 				errs = append(errs, fmt.Errorf("failed to cleanup generated resources after error: %w", err))
 			}
 		}
@@ -323,7 +323,7 @@ func (r *CK8sControlPlaneReconciler) generateCK8sConfig(ctx context.Context, kcp
 		Spec: *spec,
 	}
 
-	if err := r.Client.Create(ctx, bootstrapConfig); err != nil {
+	if err := r.Create(ctx, bootstrapConfig); err != nil {
 		return nil, fmt.Errorf("failed to create bootstrap configuration: %w", err)
 	}
 
@@ -381,7 +381,7 @@ func (r *CK8sControlPlaneReconciler) generateMachine(ctx context.Context, kcp *c
 
 	machine.SetAnnotations(annotations)
 
-	if err := r.Client.Create(ctx, machine); err != nil {
+	if err := r.Create(ctx, machine); err != nil {
 		return fmt.Errorf("failed to create machine: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/canonical/cluster-api-k8s
 
-go 1.23.0
-
-toolchain go1.23.8
+go 1.24.0
 
 require (
 	github.com/canonical/k8s-snap-api v1.0.25
@@ -109,7 +107,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/cluster-api-k8s/tools
 
-go 1.22.4
+go 1.24.0
 
 require github.com/regclient/regclient v0.7.1
 

--- a/pkg/ck8s/workload_cluster.go
+++ b/pkg/ck8s/workload_cluster.go
@@ -577,7 +577,7 @@ func (w *Workload) UpdateAgentConditions(ctx context.Context, controlPlane *Cont
 		}
 
 		// If the machine is deleting, report all the conditions as deleting
-		if !machine.ObjectMeta.DeletionTimestamp.IsZero() {
+		if !machine.DeletionTimestamp.IsZero() {
 			for _, condition := range allMachinePodConditions {
 				conditions.MarkFalse(machine, condition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
 			}

--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -48,12 +48,13 @@ RUN apt-get update \
 ## NOTE(neoaggelos): Go version used to build components
 ## !!!IMPORTANT!!! Keep up to date with "snapcraft.yaml:parts.build-deps.build-snaps.go"
 ADD install-go.sh /
-RUN /install-go.sh 1.24.0 && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 ## Prepare build environment
 ENV SNAPCRAFT_PART_INSTALL=/out
 RUN mkdir /out /build -p
 RUN git clone ${REPO} /src/k8s-snap -b ${BRANCH}
+
+RUN /install-go.sh $(grep '^go ' /src/k8s-snap/src/k8s/go.mod | cut -d' ' -f2) && ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 ####################################################################################################
 ## IMAGE(builder-dqlite): Used as base image for building components that need dqlite


### PR DESCRIPTION
- Updates go version references in various different files to be derived from the `go.mod`
- Bumps go to 1.24
- Bumps golangci-lint to v2.3.0
- Fixes new static check errors detected after golangci-lint bump