### PR TITLE
ci: fix prereleases ci

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/prerelease.yaml
-  push:
-    branches:
-      - KU-3928/fix-prereleases-ci
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Description

This PR fixes the pre-releases CI, the workflow was missing write permissions to create and push the tags.