### PR TITLE
proxy: snapd requires restart when proxies are configured

### DIFF
--- a/pkg/cloudinit/scripts/configure-proxy.sh
+++ b/pkg/cloudinit/scripts/configure-proxy.sh
@@ -25,3 +25,7 @@ if [ -f ${NO_PROXY_FILE} ]; then
   echo "no_proxy=${NO_PROXY}" >> "${ENVIRONMENT_FILE}"
   echo "NO_PROXY=${NO_PROXY}" >> "${ENVIRONMENT_FILE}"
 fi
+
+# Note(ader1990): snapd services needs to be restarted
+#   to use the new proxy settings.
+systemctl restart snapd


### PR DESCRIPTION
When http proxies are configured by the cloud-init runcmd `configure-proxy.sh`, the snapd systemd unit is already running and  not inheriting the new contents of /etc/environment.

A restart of the `snapd` systemd unit make sure that the snapd uses those proxies. Otherwise, any `snap install` or other `snap <cmd>` fail, as all those sub-commands try to reach "http://api.snapcraft.io".