### PR TITLE
snap-k8s: do not use the snap install dangerous flag

### DIFF
--- a/pkg/cloudinit/scripts/install.sh
+++ b/pkg/cloudinit/scripts/install.sh
@@ -46,7 +46,8 @@ elif [ -f "/capi/etc/snap-local-path" ]; then
   if [[ -d "${snap_local_path}" ]]; then
     snap_local_paths=($(ls ${snap_local_path}/*.snap))
   fi
-  retry_snap_install snap install --classic --dangerous "${snap_local_paths[@]}"
+  ls ${snap_local_path}/*.assert | xargs -L 1 snap ack
+  retry_snap_install snap install --classic "${snap_local_paths[@]}"
 else
   echo "No snap installation option found"
   exit 1


### PR DESCRIPTION
When using the `snap install --dangerous <path_to_local_snap_binary>`, the revision is set to `x1` instead of the real revision.

This behaviour breaks the rolling upgrade for the minor k8s versions, as the rolling upgrade needs an actual revision number.

Fixes: https://github.com/canonical/cluster-api-k8s/issues/193