### PR TITLE
chore: remove codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*               @canonical/kubernetes


### PR DESCRIPTION
In this way we want to reduce email spam as we did in the k8s-snap.