### PR TITLE
fix: Remove node without the force flag

### DIFF
--- a/pkg/ck8s/workload_cluster.go
+++ b/pkg/ck8s/workload_cluster.go
@@ -453,7 +453,7 @@ func (w *Workload) RemoveMachineFromCluster(ctx context.Context, machine *cluste
 	}
 
 	nodeName := machine.Status.NodeRef.Name
-	request := &apiv1.RemoveNodeRequest{Name: nodeName, Force: true}
+	request := &apiv1.RemoveNodeRequest{Name: nodeName}
 
 	// If we see that ignoring control-planes is causing issues, let's consider removing it.
 	// It *should* not be necessary as a machine should be able to remove itself from the cluster.


### PR DESCRIPTION
This PR removes the `force` flag from the `RemoveNode` call in order to retry in case of a removal failure.

Fixes: https://github.com/canonical/cluster-api-k8s/issues/192