### PR TITLE
Removing stray quotes in --provider-id: openstack:///'{{ instance_id }}' template

### DIFF
--- a/templates/openstack/cluster-template.yaml
+++ b/templates/openstack/cluster-template.yaml
@@ -17,7 +17,7 @@ spec:
     controlPlane:
       cloudProvider: external
     extraKubeletArgs:
-      --provider-id: openstack:///'{{ instance_id }}'
+      --provider-id: openstack:///{{ instance_id }}
   machineTemplate:
     infrastructureTemplate:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -60,7 +60,7 @@ spec:
       controlPlane:
         cloudProvider: external
       extraKubeletArgs:
-        --provider-id: openstack:///'{{ instance_id }}'
+        --provider-id: openstack:///{{ instance_id }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster


### PR DESCRIPTION
This PR removes stray quotes in --provider-id: openstack:///'{{ instance_id }}' that avoid control plane bootstrap finnish correctly

Fixes: #[178](https://github.com/canonical/cluster-api-k8s/issues/178)