### PR TITLE
feat: Prep for v0.6.0 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,3 +16,6 @@ releaseSeries:
   - major: 0
     minor: 5
     contract: v1beta1
+  - major: 0
+    minor: 6
+    contract: v1beta1

--- a/test/e2e/config/ck8s-aws.yaml
+++ b/test/e2e/config/ck8s-aws.yaml
@@ -61,7 +61,7 @@ providers:
       # ${ProjectRoot}/metadata.yaml to init the management cluster
       # this version should be updated when ${ProjectRoot}/metadata.yaml
       # is modified
-      - name: v0.5.99 # next; use manifest from source files
+      - name: v0.6.99 # next; use manifest from source files
         value: "../../../bootstrap/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/bootstrap-controller:latest"
@@ -71,7 +71,7 @@ providers:
   - name: ck8s
     type: ControlPlaneProvider
     versions:
-      - name: v0.5.99 # next; use manifest from source files
+      - name: v0.6.99 # next; use manifest from source files
         value: "../../../controlplane/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/controlplane-controller:latest"

--- a/test/e2e/config/ck8s-docker.yaml
+++ b/test/e2e/config/ck8s-docker.yaml
@@ -64,7 +64,7 @@ providers:
       # ${ProjectRoot}/metadata.yaml to init the management cluster
       # this version should be updated when ${ProjectRoot}/metadata.yaml
       # is modified
-      - name: v0.5.99 # next; use manifest from source files
+      - name: v0.6.99 # next; use manifest from source files
         value: "../../../bootstrap/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/bootstrap-controller:latest"
@@ -75,7 +75,7 @@ providers:
   - name: ck8s
     type: ControlPlaneProvider
     versions:
-      - name: v0.5.99 # next; use manifest from source files
+      - name: v0.6.99 # next; use manifest from source files
         value: "../../../controlplane/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/controlplane-controller:latest"

--- a/test/e2e/config/ck8s-incus.yaml
+++ b/test/e2e/config/ck8s-incus.yaml
@@ -49,7 +49,7 @@ providers:
       # ${ProjectRoot}/metadata.yaml to init the management cluster
       # this version should be updated when ${ProjectRoot}/metadata.yaml
       # is modified
-      - name: v0.5.99 # next; use manifest from source files
+      - name: v0.6.99 # next; use manifest from source files
         value: "../../../bootstrap/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/bootstrap-controller:latest"
@@ -60,7 +60,7 @@ providers:
   - name: ck8s
     type: ControlPlaneProvider
     versions:
-      - name: v0.5.99 # next; use manifest from source files
+      - name: v0.6.99 # next; use manifest from source files
         value: "../../../controlplane/config/default"
         replacements:
           - old: "ghcr.io/canonical/cluster-api-k8s/controlplane-controller:latest"


### PR DESCRIPTION
### Overview

This PR does some prep work for the v0.6.0 release. We'll need to create a v0.6.0 tag with the release notes as soon as this PR is merged.

The most important change in this release is the removal of k8s-dqlite. It's important for the release notes to cover this area in particular since we've not deprecated anything, but actually removed the pieces responsible for handling k8s-dqlite. 