### PR TITLE
fix(release-0.4): pin trivy-action to v0.35.0 by SHA (GHSA-69fq-xp46-6x23)

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: "fs"
           ignore-unfixed: true


### PR DESCRIPTION
Pin trivy-action to SHA-pinned v0.35.0 (`57a97c7e7821a5776cebc9bb87c984fa69cba8f1`).

Backport of the fix on the default branch.

Context: [GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)