### PR TITLE
Update Canonical K8s CAPI cluster to get ready when enableDefaultNetwork is set as false

### DIFF
--- a/controlplane/controllers/ck8scontrolplane_controller.go
+++ b/controlplane/controllers/ck8scontrolplane_controller.go
@@ -395,12 +395,24 @@ func (r *CK8sControlPlaneReconciler) updateStatus(ctx context.Context, kcp *cont
 	kcp.Status.ReadyReplicas = status.ReadyNodes
 	kcp.Status.UnavailableReplicas = replicas - status.ReadyNodes
 
-	// NOTE(neoaggelos): We consider the control plane to be initialized iff the k8sd-config exists
-	if status.HasK8sdConfigMap {
+	enableDefaultNetwork := kcp.Spec.CK8sConfigSpec.InitConfig.GetEnableDefaultNetwork()
+
+	// NOTE(neoaggelos): We consider the control plane to be initialized iff the k8sd-config exists.
+	// When enableDefaultNetwork is false (user-managed CNI), k8sd-config may not appear until CNI
+	// is installed, so we fall back to API-server accessibility (ClusterStatus succeeded + replicas
+	// exist) to break the initialization deadlock and allow the MAAS controller to proceed.
+	if status.HasK8sdConfigMap || (!enableDefaultNetwork && replicas > 0) {
 		kcp.Status.Initialized = true
 	}
 
-	if kcp.Status.ReadyReplicas > 0 {
+	// When default network is disabled, nodes remain NotReady until the external CNI is
+	// installed by user. Mark the control plane Ready/Available as soon as
+	// it is initialized so that ControlPlaneInitializedCondition propagates to the Cluster object
+	// and the CAPI ClusterCacheTracker can establish a remote connection.
+	// Nodes will transition to Ready once CNI is applied, at which point ReadyReplicas > 0 and
+	// the normal path also satisfies this condition.
+	if kcp.Status.ReadyReplicas > 0 ||
+		(!enableDefaultNetwork && kcp.Status.Initialized && replicas > 0) {
 		kcp.Status.Ready = true
 		conditions.MarkTrue(kcp, controlplanev1.AvailableCondition)
 	}

--- a/pkg/ck8s/manifests/k8sd-proxy-template.yaml
+++ b/pkg/ck8s/manifests/k8sd-proxy-template.yaml
@@ -29,6 +29,12 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoExecute
+      - key: node.kubernetes.io/unreachable
+        operator: Exists
+        effect: NoExecute
       containers:
       - name: k8sd-proxy
         image: ghcr.io/canonical/cluster-api-k8s/socat:1.8.0.0


### PR DESCRIPTION
This PR lets CK8s mark the `CK8sControlPlane` object as `Ready` when default CNI is disabled in spec:
```
spec:
  initConfig:
    enableDefaultNetwork: false
```

It also lets `k8sd-proxy` daemonset to get scheduled on the `NotReady` node so that once the user installs CNI on the CAPI Canonical K8s cluster, the `k8sd-proxy` daemonset will also be up and running.

An elongated discussion is present here and this PR marks the resolution of the issue: https://github.com/canonical/cluster-api-k8s/issues/169