### PR TITLE
cluster_join: retry join for 3 times with 60 seconds wait time

### DIFF
--- a/pkg/cloudinit/scripts/join-cluster.sh
+++ b/pkg/cloudinit/scripts/join-cluster.sh
@@ -10,4 +10,27 @@ name="$(cat /capi/etc/node-name)"
 config_file="/capi/etc/config.yaml"
 token="$(cat /capi/etc/join-token)"
 
-k8s join-cluster "${token}" --name "${name}" --address "${address}" --file "${config_file}"
+max_attempts=3
+delay=60
+current_attempt=1
+
+while [ $current_attempt -le $max_attempts ]; do
+
+  echo "Attempt $current_attempt of $max_attempts to join cluster..."
+  k8s join-cluster "${token}" --name "${name}" --address "${address}" --file "${config_file}"
+  clusterJoinExitCode=$?
+  if [ $clusterJoinExitCode -eq 0 ]; then
+    echo "Cluster join succeeded"
+    exit 0
+  else
+    echo "Cluster join failed"
+    if [ $current_attempt -lt $max_attempts ]; then
+      echo "Retrying in $delay seconds..."
+      sleep $delay
+    fi
+  fi
+  current_attempt=$((current_attempt + 1))
+done
+
+echo "Failed to join cluster after $max_attempts attempts"
+exit 1


### PR DESCRIPTION
Cluster join can fail if the control plane to be joined is temporarily unavailable due to transient network failures.

This can happen during rolling upgrades when the ControlPlane that is servicing the join is being replaced or not in a serviceable state.

Adding 3 retries with a 60 seconds timeout should fix all of the issues.

Fixes: https://github.com/canonical/cluster-api-k8s/issues/220